### PR TITLE
Adding setup, build & test scripts for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Windows:
 
 Linux:
 ```bash
-source ./scripts/Setup.sh
+source ./scripts/setup.sh
 ```
 
 The script can be run multiple times as it does not replace what has been installed, and updates dependencies.

--- a/scripts/Setup.ps1
+++ b/scripts/Setup.ps1
@@ -3,7 +3,7 @@
 
 <#
 .SYNOPSIS
-Setups dependencies required to build and work with the SFS Client.
+Sets up dependencies required to build and work with the SFS Client.
 
 .DESCRIPTION
 This script will install all of the dependencies required to build and work with the SFS Client.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,24 +9,32 @@
 # Use this on non-Windows platforms in a bash session.
 #
 # Example:
-# $ ./scripts/Build.sh
+# $ ./scripts/build.sh
 #
 
-RED="\033[1;31m"
-YELLOW="\033[1;33m"
-NC="\033[0m" # No color
+# Ensures script stops on errors
+set -e
 
-error() { echo -e "${RED}$*${NC}" >&2; }
-warn() { echo -e "${YELLOW}$*${NC}"; }
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    error "Script is being sourced, it should be executed instead."
+    return 1
+fi
+
+COLOR_RED="\033[1;31m"
+COLOR_YELLOW="\033[1;33m"
+NO_COLOR="\033[0m"
+
+error() { echo -e "${COLOR_RED}$*${NO_COLOR}" >&2; exit 1; }
+warn() { echo -e "${COLOR_YELLOW}$*${NO_COLOR}"; }
 
 clean=false
 
-usage() { echo "Usage: $0 [--clean]" 1>&2; exit 1; }
+usage() { echo "Usage: $0 [-c|--clean]" 1>&2; exit 1; }
 
 if ! opts=$(getopt \
   --longoptions "clean" \
   --name "$(basename "$0")" \
-  --options "" \
+  --options "c" \
   -- "$@"
 ); then
     usage
@@ -36,7 +44,7 @@ eval set "--$opts"
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --clean)
+        -c|--clean)
             clean=true
             shift 1
             ;;
@@ -51,7 +59,7 @@ git_root=$(git -C "$script_dir" rev-parse --show-toplevel)
 
 vcpkg_dir="$git_root/vcpkg"
 if [ ! -d "$vcpkg_dir" ]; then
-    error "vcpkg not found at $git_root\vcpkg. Run the Setup.ps1 script first."
+    error "vcpkg not found at $git_root/vcpkg. Source the setup.sh script first."
 fi
 
 build_folder="$git_root/build"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@
 # Use this on non-Windows platforms in a bash session.
 #
 # Example:
-# $ ./scripts/Test.sh
+# $ ./scripts/test.sh
 #
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"


### PR DESCRIPTION
Closes #13.

Creating bash versions of Setup.ps1, Build.ps1 and Test.ps1 so development can be done on Ubuntu.

I have tested it all on WSL2 with Ubuntu 22.04.3.
Scripts have been passed through shellcheck to look for bugs.

Change in SFSClientTool.cpp came from a warning, using int for comparisons against size_t.