### PR TITLE
Defining operator<< for Result to have better catch2 errors

### DIFF
--- a/client/include/sfsclient/Result.h
+++ b/client/include/sfsclient/Result.h
@@ -53,3 +53,6 @@ class Result
 
 std::string_view ToString(Result::Code code) noexcept;
 } // namespace SFS
+
+std::ostream& operator<<(std::ostream& os, const SFS::Result& value);
+std::ostream& operator<<(std::ostream& os, const SFS::Result::Code& value);

--- a/client/src/Result.cpp
+++ b/client/src/Result.cpp
@@ -3,6 +3,8 @@
 
 #include "Result.h"
 
+#include <ostream>
+
 using namespace SFS;
 
 Result::Result(Code code) noexcept : m_code(code)
@@ -72,4 +74,16 @@ std::string_view SFS::ToString(Result::Code code) noexcept
         return "E_Unexpected";
     }
     return "";
+}
+
+std::ostream& operator<<(std::ostream& os, const Result& result)
+{
+    os << ToString(result.GetCode());
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Result::Code& code)
+{
+    os << ToString(code);
+    return os;
 }


### PR DESCRIPTION
Folllowing catch2 guidance from https://github.com/catchorg/Catch2/blob/devel/docs/tostring.md
Defining this operator allows catch2 to report the string representing a `Result`, rather than using the `bool` operator and just reporting 0 or 1 on errors.