### PR TITLE
Fixing gcc warning: comparison of integer expression of different signedness

### DIFF
--- a/tool/SFSClientTool.cpp
+++ b/tool/SFSClientTool.cpp
@@ -64,7 +64,7 @@ int ParseArguments(const std::vector<std::string_view>& args, Settings& settings
     settings = {};
     settings.displayHelp = args.size() == 1;
 
-    for (int i = 1; i < args.size(); ++i)
+    for (size_t i = 1; i < args.size(); ++i)
     {
         if (args[i].compare("-h") == 0 || args[i].compare("--help") == 0)
         {


### PR DESCRIPTION
Fixing compilation warning that shows up when compiling in gcc:

```
./sfs-client/tool/SFSClientTool.cpp:60:23: error: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::basic_string_view<char> >::size_type’ {aka ‘long unsigned int’} [-Werror=sign-compare]
   60 |     for (int i = 1; i < args.size(); ++i)
```