### PR TITLE
Enable some MSVC warnings turned off by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,18 +24,18 @@ if(MSVC)
     # Enable some MSVC warnings that are off by default:
     #
     # * 4062: all enums are handled in switch statements without a default label
+    # * 4191: unsafe conversion from 'type of expression' to 'type required'
+    # * 4242: possible loss of data (identifier)
+    # * 4254: possible loss of data (operator)
     # * 4287: 'operator': unsigned/negative constant mismatch
     # * 4296: 'operator': expression is always true (or false)
     # * 4388: signed/unsigned mismatch
     # * 4800: implicit conversion to bool; possible information loss
-    add_compile_options(
-        /W4
-        /WX
-        /we4062
-        /we4287
-        /we4296
-        /we4388
-        /we4800)
+    # * 4946: reinterpret_cast used between related classes
+
+    # cmake-format: off
+    add_compile_options(/W4 /WX /we4062 /we4191 /we4242 /we4254 /we4287 /we4296 /we4388 /we4800 /we4946)
+    # cmake-format: on
 else()
     add_compile_options(
         -Wall


### PR DESCRIPTION
Enable some MSVC warnings turned off by default.
Would have helped catch #23 in MSVC as well.