### PR TITLE
Using safe Windows version of gmtime in SFSClientTool

### DIFF
--- a/tool/SFSClientTool.cpp
+++ b/tool/SFSClientTool.cpp
@@ -10,9 +10,6 @@
 #include <time.h>
 #include <vector>
 
-// Avoid warnings on gmtime being unsafe, gmtime is the portable version of gmtime_s
-#pragma warning(disable : 4996)
-
 using namespace SFS;
 
 namespace
@@ -200,7 +197,13 @@ std::string TimestampToString(std::chrono::time_point<std::chrono::system_clock>
     auto timer = system_clock::to_time_t(time);
 
     std::stringstream timeStream;
-    timeStream << std::put_time(std::gmtime(&timer), "%F %X"); // yyyy-mm-dd HH:MM:SS
+    struct tm gmTime;
+#ifdef _WIN32
+    gmtime_s(&gmTime, &timer); // gmtime_s is the safe version of gmtime, not available on Linux
+#else
+    gmTime = (*std::gmtime(&timer));
+#endif
+    timeStream << std::put_time(&gmTime, "%F %X"); // yyyy-mm-dd HH:MM:SS
     timeStream << '.' << std::setfill('0') << std::setw(3) << ms.count();
 
     return timeStream.str();


### PR DESCRIPTION
~Helps #8 which will contain platform-specific code.~

~Adding defines through CMake that identify the platform so we can enable platform-specific code.
Using it in SFSClientTool.cpp to wrap a pragma that only works in MSVC => Windows.
Platforms are [Windows](https://cmake.org/cmake/help/latest/variable/WIN32.html) and [Unix](https://cmake.org/cmake/help/latest/variable/UNIX.html) systems, which include Apple.~

Jeff showed the _WIN32 define already exists to do this.
I've used it in SFSClientTool to use the safe windows version of gmtime, which is not available in Linux.