### PR TITLE
Showing test output on failure in PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,6 @@ jobs:
 
       - name: Test
         shell: pwsh
-        run: .\scripts\Test.ps1
+        run: .\scripts\Test.ps1 -OutputOnFailure
 
   # TODO: implement build-ubuntu job

--- a/scripts/Test.ps1
+++ b/scripts/Test.ps1
@@ -12,8 +12,17 @@ Use this on Windows platforms in a PowerShell session.
 .EXAMPLE
 PS> ./scripts/Test.ps1
 #>
+param (
+    [switch] $OutputOnFailure = $false
+)
 
 $GitRoot = (Resolve-Path (&git -C $PSScriptRoot rev-parse --show-toplevel)).Path
 $BuildFolder = "$GitRoot/build"
 
-ctest --test-dir "$BuildFolder/client"
+$cmd = "ctest --test-dir ""$BuildFolder/client"""
+if ($OutputOnFailure)
+{
+    $cmd += " --output-on-failure"
+}
+
+Invoke-Expression $cmd

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,8 +12,49 @@
 # $ ./scripts/test.sh
 #
 
+# Ensures script stops on errors
+set -e
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    error "Script is being sourced, it should be executed instead."
+    return 1
+fi
+
+output_on_failure=false
+
+usage() { echo "Usage: $0 [--output-on-failure]" 1>&2; exit 1; }
+
+if ! opts=$(getopt \
+  --longoptions "output-on-failure" \
+  --name "$(basename "$0")" \
+  --options "" \
+  -- "$@"
+); then
+    usage
+fi
+
+eval set "--$opts"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --output-on-failure)
+            output_on_failure=true
+            shift 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 git_root=$(git -C "$script_dir" rev-parse --show-toplevel)
 build_folder="$git_root/build"
 
-ctest --test-dir "$build_folder/client"
+cmd="ctest --test-dir \"$build_folder/client\""
+
+if $output_on_failure ; then
+    cmd+=" --output-on-failure"
+fi
+
+eval "$cmd"


### PR DESCRIPTION
Closes #4

Currently when the test step of the pipeline fails, the "ctest" command generates a failure log to a local file that is not accessible from the pipeline.
Example: https://github.com/microsoft/sfs-client/actions/runs/7661415433/job/20880749228

This PR allows the failure output to be displayed directly on the actions page instead.