### PR TITLE
Removing prefix on Result codes

### DIFF
--- a/client/include/sfsclient/Result.h
+++ b/client/include/sfsclient/Result.h
@@ -14,19 +14,21 @@ class Result
   public:
     enum Code : uint32_t
     {
-        S_Ok = 0x00000000,
-        E_ConnectionSetupFailed = 0x80000001,
-        E_ConnectionUnexpectedError = 0x80000002,
-        E_HttpBadRequest = 0x80000003,
-        E_HttpNotFound = 0x80000004,
-        E_HttpTimeout = 0x80000005,
-        E_HttpServiceNotAvailable = 0x80000006,
-        E_HttpUnexpected = 0x80000007,
-        E_InvalidArg = 0x80000008,
-        E_NotImpl = 0x80000009,
-        E_NotSet = 0x8000000A,
-        E_OutOfMemory = 0x8000000B,
-        E_Unexpected = 0x8000000C,
+        // Represents a successful operation
+        Success = 0x00000000,
+        // Represents a failed operation
+        ConnectionSetupFailed = 0x80000001,
+        ConnectionUnexpectedError = 0x80000002,
+        HttpBadRequest = 0x80000003,
+        HttpNotFound = 0x80000004,
+        HttpServiceNotAvailable = 0x80000005,
+        HttpTimeout = 0x80000006,
+        HttpUnexpected = 0x80000007,
+        InvalidArg = 0x80000008,
+        NotImpl = 0x80000009,
+        NotSet = 0x8000000A,
+        OutOfMemory = 0x8000000B,
+        Unexpected = 0x8000000C,
     };
 
     Result(Code code) noexcept;

--- a/client/include/sfsclient/SFSClient.h
+++ b/client/include/sfsclient/SFSClient.h
@@ -73,7 +73,7 @@ class SFSClient
 
     /**
      * @brief Retrieve Delivery Optimization data for a given piece of content, if existing
-     * @details If the Delivery Optimization data is not available, the result code will be set to E_NotSet
+     * @details If the Delivery Optimization data is not available, the result code will be set to Result::NotSet
      * and the param data will not be modified
      * @param content A content object that was returned from a previous call to GetDownloadInfo
      * @param data A DeliveryOptimizationData object that is populated with the result
@@ -83,7 +83,7 @@ class SFSClient
 
     /**
      * @brief Retrieve Applicability details for a given piece of content, if existing
-     * @details If the Applicability details are not available, the result code will be set to E_NotSet
+     * @details If the Applicability details are not available, the result code will be set to Result::NotSet
      * and the param details will not be modified
      * @param content A content object that was returned from a previous call to GetDownloadInfo
      * @param data A ApplicabilityDetails object that is populated with the result

--- a/client/src/ApplicabilityDetails.cpp
+++ b/client/src/ApplicabilityDetails.cpp
@@ -24,7 +24,7 @@ try
 
     out = std::move(tmp);
 
-    return Result::S_Ok;
+    return Result::Success;
 }
 SFS_CATCH_RETURN()
 

--- a/client/src/Content.cpp
+++ b/client/src/Content.cpp
@@ -26,7 +26,7 @@ try
 
     out = std::move(tmp);
 
-    return Result::S_Ok;
+    return Result::Success;
 }
 SFS_CATCH_RETURN()
 
@@ -73,7 +73,7 @@ try
 
     out = std::move(tmp);
 
-    return Result::S_Ok;
+    return Result::Success;
 }
 SFS_CATCH_RETURN()
 
@@ -137,7 +137,7 @@ try
 
     out = std::move(tmp);
 
-    return Result::S_Ok;
+    return Result::Success;
 }
 SFS_CATCH_RETURN()
 
@@ -159,7 +159,7 @@ try
 
     out = std::move(tmp);
 
-    return Result::S_Ok;
+    return Result::Success;
 }
 SFS_CATCH_RETURN()
 

--- a/client/src/DeliveryOptimizationData.cpp
+++ b/client/src/DeliveryOptimizationData.cpp
@@ -21,7 +21,7 @@ try
     tmp->m_properties = std::move(properties);
 
     out = std::move(tmp);
-    return Result::S_Ok;
+    return Result::Success;
 }
 SFS_CATCH_RETURN()
 

--- a/client/src/Result.cpp
+++ b/client/src/Result.cpp
@@ -35,7 +35,7 @@ const std::string& Result::GetMessage() const noexcept
 
 bool Result::IsSuccess() const noexcept
 {
-    return GetCode() == S_Ok;
+    return GetCode() == Success;
 }
 
 bool Result::IsFailure() const noexcept
@@ -62,32 +62,34 @@ std::string_view SFS::ToString(Result::Code code) noexcept
 {
     switch (code)
     {
-    case Result::S_Ok:
-        return "S_Ok";
-    case Result::E_ConnectionSetupFailed:
-        return "E_ConnectionSetupFailed";
-    case Result::E_ConnectionUnexpectedError:
-        return "E_ConnectionUnexpectedError";
-    case Result::E_HttpBadRequest:
-        return "E_HttpBadRequest";
-    case Result::E_HttpNotFound:
-        return "E_HttpNotFound";
-    case Result::E_HttpTimeout:
-        return "E_HttpTimeout";
-    case Result::E_HttpServiceNotAvailable:
-        return "E_HttpServiceNotAvailable";
-    case Result::E_HttpUnexpected:
-        return "E_HttpUnexpected";
-    case Result::E_InvalidArg:
-        return "E_InvalidArg";
-    case Result::E_NotImpl:
-        return "E_NotImpl";
-    case Result::E_NotSet:
-        return "E_NotSet";
-    case Result::E_OutOfMemory:
-        return "E_OutOfMemory";
-    case Result::E_Unexpected:
-        return "E_Unexpected";
+    // Represents a successful operation
+    case Result::Success:
+        return "Success";
+    // Represents a failed operation
+    case Result::ConnectionSetupFailed:
+        return "ConnectionSetupFailed";
+    case Result::ConnectionUnexpectedError:
+        return "ConnectionUnexpectedError";
+    case Result::HttpBadRequest:
+        return "HttpBadRequest";
+    case Result::HttpNotFound:
+        return "HttpNotFound";
+    case Result::HttpServiceNotAvailable:
+        return "HttpServiceNotAvailable";
+    case Result::HttpTimeout:
+        return "HttpTimeout";
+    case Result::HttpUnexpected:
+        return "HttpUnexpected";
+    case Result::InvalidArg:
+        return "InvalidArg";
+    case Result::NotImpl:
+        return "NotImpl";
+    case Result::NotSet:
+        return "NotSet";
+    case Result::OutOfMemory:
+        return "OutOfMemory";
+    case Result::Unexpected:
+        return "Unexpected";
     }
     return "";
 }

--- a/client/src/SFSClient.cpp
+++ b/client/src/SFSClient.cpp
@@ -19,14 +19,14 @@ try
 {
     if (config.accountId.empty())
     {
-        return Result(Result::E_InvalidArg, "ClientConfig::accountId cannot be empty");
+        return Result(Result::InvalidArg, "ClientConfig::accountId cannot be empty");
     }
 
     out.reset();
     std::unique_ptr<SFSClient> tmp(new SFSClient());
     tmp->m_impl = std::make_unique<details::SFSClientImpl<CurlConnectionManager>>(std::move(config));
     out = std::move(tmp);
-    return Result::S_Ok;
+    return Result::Success;
 }
 SFS_CATCH_RETURN()
 
@@ -35,7 +35,7 @@ Result SFSClient::GetLatestDownloadInfo([[maybe_unused]] std::string_view produc
 try
 {
     // return m_impl->GetDownloadInfo(...);
-    return Result::E_NotImpl;
+    return Result::NotImpl;
 }
 SFS_CATCH_RETURN()
 
@@ -45,7 +45,7 @@ Result SFSClient::GetLatestDownloadInfo([[maybe_unused]] std::string_view produc
 try
 {
     // return m_impl->GetDownloadInfo(...);
-    return Result::E_NotImpl;
+    return Result::NotImpl;
 }
 SFS_CATCH_RETURN()
 
@@ -55,7 +55,7 @@ Result SFSClient::GetDeliveryOptimizationData(
 try
 {
     // return m_impl->GetDeliveryOptimizationData(...);
-    return Result::E_NotImpl;
+    return Result::NotImpl;
 }
 SFS_CATCH_RETURN()
 
@@ -65,6 +65,6 @@ Result SFSClient::GetApplicabilityDetails(
 try
 {
     // return m_impl->GetApplicabilityDetails(...);
-    return Result::E_NotImpl;
+    return Result::NotImpl;
 }
 SFS_CATCH_RETURN()

--- a/client/src/details/ErrorHandling.h
+++ b/client/src/details/ErrorHandling.h
@@ -9,7 +9,7 @@
 #define SFS_CATCH_RETURN()                                                                                             \
     catch (const std::bad_alloc&)                                                                                      \
     {                                                                                                                  \
-        return Result::E_OutOfMemory;                                                                                  \
+        return Result::OutOfMemory;                                                                                    \
     }                                                                                                                  \
     catch (const SFS::details::SFSException& e)                                                                        \
     {                                                                                                                  \
@@ -17,11 +17,11 @@
     }                                                                                                                  \
     catch (const std::exception&)                                                                                      \
     {                                                                                                                  \
-        return Result::E_Unexpected;                                                                                   \
+        return Result::Unexpected;                                                                                     \
     }                                                                                                                  \
     catch (...)                                                                                                        \
     {                                                                                                                  \
-        return Result::E_Unexpected;                                                                                   \
+        return Result::Unexpected;                                                                                     \
     }
 
 #define RETURN_IF_FAILED(result)                                                                                       \

--- a/client/src/details/SFSClientImpl.cpp
+++ b/client/src/details/SFSClientImpl.cpp
@@ -43,7 +43,7 @@ Result SFSClientImpl<ConnectionManagerT>::GetLatestVersion(
     [[maybe_unused]] std::unique_ptr<VersionResponse>& response) const
 {
     LOG_INFO(m_reportingHandler, "GetLatestVersion not implemented");
-    return Result::E_NotImpl;
+    return Result::NotImpl;
 }
 
 template <typename ConnectionManagerT>
@@ -54,7 +54,7 @@ Result SFSClientImpl<ConnectionManagerT>::GetSpecificVersion(
     [[maybe_unused]] Connection& connection,
     [[maybe_unused]] std::unique_ptr<VersionResponse>& content) const
 {
-    return Result::E_NotImpl;
+    return Result::NotImpl;
 }
 
 template <typename ConnectionManagerT>
@@ -65,7 +65,7 @@ Result SFSClientImpl<ConnectionManagerT>::GetDownloadInfo(
     [[maybe_unused]] Connection& connection,
     [[maybe_unused]] std::unique_ptr<DownloadInfoResponse>& content) const
 {
-    return Result::E_NotImpl;
+    return Result::NotImpl;
 }
 
 template <typename ConnectionManagerT>

--- a/client/src/details/connection/CurlConnectionManager.cpp
+++ b/client/src/details/connection/CurlConnectionManager.cpp
@@ -17,13 +17,13 @@ namespace
 void CheckCurlFeatures(const ReportingHandler& handler)
 {
     curl_version_info_data* ver = curl_version_info(CURLVERSION_NOW);
-    THROW_CODE_IF_LOG(E_HttpUnexpected, !ver, handler);
+    THROW_CODE_IF_LOG(HttpUnexpected, !ver, handler);
 
-    THROW_CODE_IF_LOG(E_HttpUnexpected, !(ver->features & CURL_VERSION_SSL), handler, "Curl was not built with SSL");
-    THROW_CODE_IF_LOG(E_HttpUnexpected, !(ver->features & CURL_VERSION_THREADSAFE), handler, "Curl is not thread safe");
+    THROW_CODE_IF_LOG(HttpUnexpected, !(ver->features & CURL_VERSION_SSL), handler, "Curl was not built with SSL");
+    THROW_CODE_IF_LOG(HttpUnexpected, !(ver->features & CURL_VERSION_THREADSAFE), handler, "Curl is not thread safe");
 
     // For thread safety we need the DNS resolutions to be asynchronous (which happens because of c-ares)
-    THROW_CODE_IF_LOG(E_HttpUnexpected,
+    THROW_CODE_IF_LOG(HttpUnexpected,
                       !(ver->features & CURL_VERSION_ASYNCHDNS),
                       handler,
                       "Curl was not built with async DNS resolutions");
@@ -32,7 +32,7 @@ void CheckCurlFeatures(const ReportingHandler& handler)
 
 CurlConnectionManager::CurlConnectionManager(const ReportingHandler& handler) : ConnectionManager(handler)
 {
-    THROW_CODE_IF_LOG(E_HttpUnexpected,
+    THROW_CODE_IF_LOG(HttpUnexpected,
                       curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK,
                       m_handler,
                       "Curl failed to initialize");

--- a/client/src/details/connection/mock/MockConnection.cpp
+++ b/client/src/details/connection/mock/MockConnection.cpp
@@ -16,10 +16,10 @@ MockConnection::~MockConnection()
 
 Result MockConnection::Get(const std::string&, std::string&)
 {
-    return Result::S_Ok;
+    return Result::Success;
 }
 
 Result MockConnection::Post(const std::string&, const std::string&, std::string&)
 {
-    return Result::S_Ok;
+    return Result::Success;
 }

--- a/client/tests/functional/details/SFSClientImplTests.cpp
+++ b/client/tests/functional/details/SFSClientImplTests.cpp
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "../../mock/MockWebServer.h"
+#include "../../util/TestHelper.h"
+#include "Responses.h"
+#include "SFSClientImpl.h"
+#include "connection/Connection.h"
+#include "connection/CurlConnectionManager.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#define TEST(...) TEST_CASE("[Functional][SFSClientImplTests] " __VA_ARGS__)
+
+using namespace SFS;
+using namespace SFS::details;
+using namespace SFS::test;
+
+namespace
+{
+void CheckProduct(const nlohmann::json& product, std::string_view name, std::string_view version)
+{
+    REQUIRE(product.is_object());
+    REQUIRE((product.contains("ContentId") && product.contains("Files")));
+    REQUIRE((product["ContentId"].contains("Namespace") && product["ContentId"].contains("Name") &&
+             product["ContentId"].contains("Version")));
+    REQUIRE(product["Files"].is_array());
+    REQUIRE(product["ContentId"]["Name"].get<std::string>() == name);
+    REQUIRE(product["ContentId"]["Version"].get<std::string>() == version);
+}
+
+void CheckProductArray(const nlohmann::json& productArray, std::string_view name, std::string_view version)
+{
+    REQUIRE(productArray.is_array());
+    REQUIRE(productArray.size() == 1);
+
+    const auto& product = productArray[0];
+    REQUIRE((product.contains("ContentId")));
+    REQUIRE((product["ContentId"].contains("Namespace") && product["ContentId"].contains("Name") &&
+             product["ContentId"].contains("Version")));
+    REQUIRE(product["ContentId"]["Name"].get<std::string>() == name);
+    REQUIRE(product["ContentId"]["Version"].get<std::string>() == version);
+}
+
+void CheckDownloadInfo(const nlohmann::json& info, const std::string& name)
+{
+    REQUIRE(info.is_array());
+    REQUIRE(info.size() == 2);
+    REQUIRE((info[0].contains("FileId") && info[1].contains("FileId")));
+    REQUIRE(info[0]["FileId"].get<std::string>() == (name + ".json"));
+    REQUIRE(info[1]["FileId"].get<std::string>() == (name + ".bin"));
+}
+} // namespace
+
+TEST("Testing class SFSClientImpl()")
+{
+    test::MockWebServer server;
+    SFSClientImpl<CurlConnectionManager> sfsClient(
+        {"testAccountId", "testInstanceId", "testNameSpace", LogCallbackToTest});
+    sfsClient.SetCustomBaseUrl(server.GetBaseUrl());
+
+    server.RegisterProduct("productName", "0.0.0.2");
+    server.RegisterProduct("productName", "0.0.0.1");
+
+    auto connection = sfsClient.GetConnectionManager().MakeConnection();
+
+    SECTION("Testing SFSClientImpl::GetLatestVersion()")
+    {
+        SECTION("No attributes")
+        {
+            std::unique_ptr<VersionResponse> response;
+            REQUIRE(sfsClient.GetLatestVersion("productName", std::nullopt, *connection, response) == Result::Success);
+            CheckProductArray(response->GetResponseData(), "productName", "0.0.0.2");
+        }
+
+        SECTION("With attributes")
+        {
+            std::unique_ptr<VersionResponse> response;
+            const SearchAttributes attributes{{"attr1", "value"}};
+            REQUIRE(sfsClient.GetLatestVersion("productName", attributes, *connection, response) == Result::Success);
+            CheckProductArray(response->GetResponseData(), "productName", "0.0.0.2");
+        }
+
+        SECTION("Wrong product name")
+        {
+            std::unique_ptr<VersionResponse> response;
+            REQUIRE(sfsClient.GetLatestVersion("badName", std::nullopt, *connection, response) == Result::HttpNotFound);
+
+            const SearchAttributes attributes{{"attr1", "value"}};
+            REQUIRE(sfsClient.GetLatestVersion("badName", attributes, *connection, response) == Result::HttpNotFound);
+        }
+    }
+
+    SECTION("Testing SFSClientImpl::GetSpecificVersion()")
+    {
+        SECTION("Getting 0.0.0.1")
+        {
+            std::unique_ptr<VersionResponse> response;
+            REQUIRE(sfsClient.GetSpecificVersion("productName", "0.0.0.1", *connection, response) == Result::Success);
+            CheckProduct(response->GetResponseData(), "productName", "0.0.0.1");
+        }
+
+        SECTION("Getting 0.0.0.2")
+        {
+            std::unique_ptr<VersionResponse> response;
+            REQUIRE(sfsClient.GetSpecificVersion("productName", "0.0.0.2", *connection, response) == Result::Success);
+            CheckProduct(response->GetResponseData(), "productName", "0.0.0.2");
+        }
+
+        SECTION("Wrong product name")
+        {
+            std::unique_ptr<VersionResponse> response;
+            REQUIRE(sfsClient.GetSpecificVersion("badName", "0.0.0.2", *connection, response) == Result::HttpNotFound);
+        }
+
+        SECTION("Wrong version")
+        {
+            std::unique_ptr<VersionResponse> response;
+            REQUIRE(sfsClient.GetSpecificVersion("productName", "0.0.0.3", *connection, response) ==
+                    Result::HttpNotFound);
+        }
+    }
+
+    SECTION("Testing SFSClientImpl::GetDownloadInfo()")
+    {
+        SECTION("Getting 0.0.0.1")
+        {
+            std::unique_ptr<DownloadInfoResponse> response;
+            REQUIRE(sfsClient.GetDownloadInfo("productName", "0.0.0.1", *connection, response) == Result::Success);
+            CheckDownloadInfo(response->GetResponseData(), "productName");
+        }
+
+        SECTION("Getting 0.0.0.2")
+        {
+            std::unique_ptr<DownloadInfoResponse> response;
+            REQUIRE(sfsClient.GetDownloadInfo("productName", "0.0.0.2", *connection, response) == Result::Success);
+            CheckDownloadInfo(response->GetResponseData(), "productName");
+        }
+
+        SECTION("Wrong product name")
+        {
+            std::unique_ptr<DownloadInfoResponse> response;
+            REQUIRE(sfsClient.GetDownloadInfo("badName", "0.0.0.2", *connection, response) == Result::HttpNotFound);
+        }
+
+        SECTION("Wrong version")
+        {
+            std::unique_ptr<DownloadInfoResponse> response;
+            REQUIRE(sfsClient.GetDownloadInfo("productName", "0.0.0.3", *connection, response) == Result::HttpNotFound);
+        }
+    }
+
+    REQUIRE(server.Stop() == Result::Success);
+}

--- a/client/tests/mock/MockWebServer.cpp
+++ b/client/tests/mock/MockWebServer.cpp
@@ -269,11 +269,11 @@ void MockWebServerImpl::ConfigureServerSettings()
         }
         catch (std::exception& e)
         {
-            m_lastException = Result(Result::E_HttpUnexpected, e.what());
+            m_lastException = Result(Result::HttpUnexpected, e.what());
         }
         catch (...)
         {
-            m_lastException = Result(Result::E_HttpUnexpected, "Unknown Exception");
+            m_lastException = Result(Result::HttpUnexpected, "Unknown Exception");
         }
         res.status = static_cast<int>(StatusCode::InternalServerError);
     });
@@ -477,7 +477,7 @@ Result MockWebServerImpl::Stop()
         LogCallbackToTest(ToLogData(data));
     }
     m_bufferedLog.clear();
-    return m_lastException.value_or(Result::S_Ok);
+    return m_lastException.value_or(Result::Success);
 }
 
 std::string MockWebServerImpl::GetUrl() const

--- a/client/tests/unit/ApplicabilityDetailsTests.cpp
+++ b/client/tests/unit/ApplicabilityDetailsTests.cpp
@@ -17,7 +17,7 @@ std::unique_ptr<ApplicabilityDetails> GetDetails(const std::vector<Architecture>
 {
     std::unique_ptr<ApplicabilityDetails> details;
     REQUIRE(ApplicabilityDetails::Make(architectures, platformApplicabilityForPackage, fileMoniker, details) ==
-            Result::S_Ok);
+            Result::Success);
     REQUIRE(details != nullptr);
     return details;
 };

--- a/client/tests/unit/ContentTests.cpp
+++ b/client/tests/unit/ContentTests.cpp
@@ -17,7 +17,7 @@ std::unique_ptr<ContentId> GetContentId(const std::string& nameSpace,
                                         const std::string& version)
 {
     std::unique_ptr<ContentId> contentId;
-    REQUIRE(ContentId::Make(nameSpace, name, version, contentId) == Result::S_Ok);
+    REQUIRE(ContentId::Make(nameSpace, name, version, contentId) == Result::Success);
     REQUIRE(contentId != nullptr);
     return contentId;
 };
@@ -28,7 +28,7 @@ std::unique_ptr<File> GetFile(const std::string& fileId,
                               const std::unordered_map<HashType, std::string>& hashes)
 {
     std::unique_ptr<File> file;
-    REQUIRE(File::Make(fileId, url, sizeInBytes, hashes, file) == Result::S_Ok);
+    REQUIRE(File::Make(fileId, url, sizeInBytes, hashes, file) == Result::Success);
     REQUIRE(file != nullptr);
     return file;
 };
@@ -39,7 +39,7 @@ std::unique_ptr<Content> GetContent(const std::string& contentNameSpace,
                                     const std::vector<std::unique_ptr<File>>& files)
 {
     std::unique_ptr<Content> content;
-    REQUIRE(Content::Make(contentNameSpace, contentName, contentVersion, files, content) == Result::S_Ok);
+    REQUIRE(Content::Make(contentNameSpace, contentName, contentVersion, files, content) == Result::Success);
     REQUIRE(content != nullptr);
     return content;
 };
@@ -156,7 +156,8 @@ TEST_SCENARIO("Testing Content::Make()")
         WHEN("A Content is created by copying the parameters")
         {
             std::unique_ptr<Content> copiedContent;
-            REQUIRE(Content::Make(contentNameSpace, contentName, contentVersion, files, copiedContent) == Result::S_Ok);
+            REQUIRE(Content::Make(contentNameSpace, contentName, contentVersion, files, copiedContent) ==
+                    Result::Success);
             REQUIRE(copiedContent != nullptr);
 
             THEN("The content elements are copies")
@@ -183,7 +184,7 @@ TEST_SCENARIO("Testing Content::Make()")
             {
                 std::unique_ptr<Content> movedContent;
                 REQUIRE(Content::Make(contentNameSpace, contentName, contentVersion, std::move(files), movedContent) ==
-                        Result::S_Ok);
+                        Result::Success);
                 REQUIRE(movedContent != nullptr);
 
                 // Checking contents
@@ -211,7 +212,7 @@ TEST("Testing Content equality operators")
     std::unique_ptr<File> file = GetFile("fileId", "url", 1 /*sizeInBytes*/, {{HashType::Sha1, "sha1"}});
 
     std::unique_ptr<File> clonedFile;
-    REQUIRE(file->Clone(clonedFile) == Result::S_Ok);
+    REQUIRE(file->Clone(clonedFile) == Result::Success);
 
     std::vector<std::unique_ptr<File>> files;
     files.push_back(std::move(file));

--- a/client/tests/unit/DeliveryOptimizationDataTests.cpp
+++ b/client/tests/unit/DeliveryOptimizationDataTests.cpp
@@ -14,7 +14,7 @@ namespace
 std::unique_ptr<DeliveryOptimizationData> GetData(const std::string& catalogId, const DOProperties& properties)
 {
     std::unique_ptr<DeliveryOptimizationData> data;
-    REQUIRE(DeliveryOptimizationData::Make(catalogId, properties, data) == Result::S_Ok);
+    REQUIRE(DeliveryOptimizationData::Make(catalogId, properties, data) == Result::Success);
     REQUIRE(data != nullptr);
     return data;
 };

--- a/client/tests/unit/ResultTests.cpp
+++ b/client/tests/unit/ResultTests.cpp
@@ -13,35 +13,35 @@ TEST("Testing Result() class methods")
 {
     SECTION("Default constructor")
     {
-        Result resultOk(Result::Code::S_Ok);
+        Result resultSuccess(Result::Code::Success);
 
-        REQUIRE(resultOk.GetCode() == Result::Code::S_Ok);
-        REQUIRE(resultOk.GetMessage().empty());
-        REQUIRE(resultOk.IsSuccess());
-        REQUIRE_FALSE(resultOk.IsFailure());
+        REQUIRE(resultSuccess.GetCode() == Result::Code::Success);
+        REQUIRE(resultSuccess.GetMessage().empty());
+        REQUIRE(resultSuccess.IsSuccess());
+        REQUIRE_FALSE(resultSuccess.IsFailure());
 
         INFO("Comparison operators");
-        REQUIRE(resultOk == Result::Code::S_Ok);
-        REQUIRE(resultOk == Result::S_Ok);
-        REQUIRE(resultOk != Result::Code::E_NotSet);
-        REQUIRE(resultOk != Result::E_NotSet);
-        REQUIRE_FALSE(resultOk == Result::E_NotSet);
+        REQUIRE(resultSuccess == Result::Code::Success);
+        REQUIRE(resultSuccess == Result::Success);
+        REQUIRE(resultSuccess != Result::Code::NotSet);
+        REQUIRE(resultSuccess != Result::NotSet);
+        REQUIRE_FALSE(resultSuccess == Result::NotSet);
 
         INFO("bool operator");
-        REQUIRE(resultOk);
+        REQUIRE(resultSuccess);
     }
 
     SECTION("Constructor with message")
     {
-        Result resultUnexpected(Result::Code::E_Unexpected, "message");
-        REQUIRE(resultUnexpected.GetCode() == Result::Code::E_Unexpected);
+        Result resultUnexpected(Result::Code::Unexpected, "message");
+        REQUIRE(resultUnexpected.GetCode() == Result::Code::Unexpected);
         REQUIRE(resultUnexpected.GetMessage() == "message");
         REQUIRE_FALSE(resultUnexpected.IsSuccess());
         REQUIRE(resultUnexpected.IsFailure());
 
         INFO("Comparison operators on constructor with message");
-        REQUIRE(resultUnexpected == Result::Code::E_Unexpected);
-        REQUIRE(resultUnexpected != Result::Code::E_NotSet);
+        REQUIRE(resultUnexpected == Result::Code::Unexpected);
+        REQUIRE(resultUnexpected != Result::Code::NotSet);
 
         INFO("bool operator");
         REQUIRE_FALSE(resultUnexpected);
@@ -50,9 +50,9 @@ TEST("Testing Result() class methods")
 
 TEST("Testing ToString(Result)")
 {
-    REQUIRE(SFS::ToString(Result::Code::S_Ok) == "S_Ok");
-    REQUIRE(SFS::ToString(Result::Code::E_NotImpl) == "E_NotImpl");
-    REQUIRE(SFS::ToString(Result::Code::E_NotSet) == "E_NotSet");
-    REQUIRE(SFS::ToString(Result::Code::E_OutOfMemory) == "E_OutOfMemory");
-    REQUIRE(SFS::ToString(Result::Code::E_Unexpected) == "E_Unexpected");
+    REQUIRE(SFS::ToString(Result::Code::Success) == "Success");
+    REQUIRE(SFS::ToString(Result::Code::NotImpl) == "NotImpl");
+    REQUIRE(SFS::ToString(Result::Code::NotSet) == "NotSet");
+    REQUIRE(SFS::ToString(Result::Code::OutOfMemory) == "OutOfMemory");
+    REQUIRE(SFS::ToString(Result::Code::Unexpected) == "Unexpected");
 }

--- a/client/tests/unit/SFSClientTests.cpp
+++ b/client/tests/unit/SFSClientTests.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<SFSClient> GetSFSClient()
     std::unique_ptr<SFSClient> sfsClient;
     ClientConfig options;
     options.accountId = "testAccountId";
-    REQUIRE(SFSClient::Make(options, sfsClient) == Result::S_Ok);
+    REQUIRE(SFSClient::Make(options, sfsClient) == Result::Success);
     REQUIRE(sfsClient != nullptr);
     return sfsClient;
 }
@@ -57,66 +57,66 @@ TEST("Testing SFSClient::Make()")
 
     SECTION("Make({accountId}, out)")
     {
-        REQUIRE(SFSClient::Make({accountId}, sfsClient) == Result::S_Ok);
+        REQUIRE(SFSClient::Make({accountId}, sfsClient) == Result::Success);
         REQUIRE(sfsClient != nullptr);
 
         ClientConfig config{accountId};
-        REQUIRE(SFSClient::Make(config, sfsClient) == Result::S_Ok);
+        REQUIRE(SFSClient::Make(config, sfsClient) == Result::Success);
         REQUIRE(sfsClient != nullptr);
     }
 
     SECTION("Make(accountId, instanceId, out)")
     {
-        REQUIRE(SFSClient::Make({accountId, instanceId}, sfsClient) == Result::S_Ok);
+        REQUIRE(SFSClient::Make({accountId, instanceId}, sfsClient) == Result::Success);
         REQUIRE(sfsClient != nullptr);
 
         ClientConfig config{accountId, instanceId};
-        REQUIRE(SFSClient::Make(config, sfsClient) == Result::S_Ok);
+        REQUIRE(SFSClient::Make(config, sfsClient) == Result::Success);
         REQUIRE(sfsClient != nullptr);
     }
 
     SECTION("Make(accountId, instanceId, namespace, out)")
     {
-        REQUIRE(SFSClient::Make({accountId, instanceId, nameSpace}, sfsClient) == Result::S_Ok);
+        REQUIRE(SFSClient::Make({accountId, instanceId, nameSpace}, sfsClient) == Result::Success);
         REQUIRE(sfsClient != nullptr);
 
         SECTION("Call make when the pointer is reset")
         {
             sfsClient.reset();
-            REQUIRE(SFSClient::Make({accountId, instanceId, nameSpace}, sfsClient) == Result::S_Ok);
+            REQUIRE(SFSClient::Make({accountId, instanceId, nameSpace}, sfsClient) == Result::Success);
             REQUIRE(sfsClient != nullptr);
         }
 
         SECTION("Call make if the pointer is not reset, as Make() resets it")
         {
-            REQUIRE(SFSClient::Make({accountId, instanceId, nameSpace}, sfsClient) == Result::S_Ok);
+            REQUIRE(SFSClient::Make({accountId, instanceId, nameSpace}, sfsClient) == Result::Success);
             REQUIRE(sfsClient != nullptr);
         }
 
         SECTION("We can also use a separate ClientConfig object")
         {
             ClientConfig config{accountId, instanceId, nameSpace};
-            REQUIRE(SFSClient::Make(config, sfsClient) == Result::S_Ok);
+            REQUIRE(SFSClient::Make(config, sfsClient) == Result::Success);
             REQUIRE(sfsClient != nullptr);
         }
 
         SECTION("We can also move a separate ClientConfig object")
         {
             ClientConfig config{accountId, instanceId, nameSpace};
-            REQUIRE(SFSClient::Make(std::move(config), sfsClient) == Result::S_Ok);
+            REQUIRE(SFSClient::Make(std::move(config), sfsClient) == Result::Success);
             REQUIRE(sfsClient != nullptr);
         }
     }
 
     SECTION("Make(accountId, std::nullopt, nameSpace, out)")
     {
-        REQUIRE(SFSClient::Make({accountId, std::nullopt, nameSpace}, sfsClient) == Result::S_Ok);
+        REQUIRE(SFSClient::Make({accountId, std::nullopt, nameSpace}, sfsClient) == Result::Success);
         REQUIRE(sfsClient != nullptr);
 
         ClientConfig config;
         config.accountId = accountId;
         config.nameSpace = nameSpace;
-        REQUIRE(SFSClient::Make(config, sfsClient) == Result::S_Ok);
+        REQUIRE(SFSClient::Make(config, sfsClient) == Result::Success);
         REQUIRE(sfsClient != nullptr);
     }
 
@@ -125,72 +125,72 @@ TEST("Testing SFSClient::Make()")
         SECTION("Using a lambda with {} initialization")
         {
             REQUIRE(SFSClient::Make({accountId, instanceId, nameSpace, [](const LogData&) {}}, sfsClient) ==
-                    Result::S_Ok);
+                    Result::Success);
             REQUIRE(sfsClient != nullptr);
         }
 
         SECTION("Using a lambda with a ClientConfig object")
         {
             ClientConfig config{accountId, instanceId, nameSpace, [](const LogData&) {}};
-            REQUIRE(SFSClient::Make(config, sfsClient) == Result::S_Ok);
+            REQUIRE(SFSClient::Make(config, sfsClient) == Result::Success);
             REQUIRE(sfsClient != nullptr);
         }
 
         SECTION("Using a nullptr with a ClientConfig object")
         {
             ClientConfig config{accountId, instanceId, nameSpace, nullptr};
-            REQUIRE(SFSClient::Make(config, sfsClient) == Result::S_Ok);
+            REQUIRE(SFSClient::Make(config, sfsClient) == Result::Success);
             REQUIRE(sfsClient != nullptr);
         }
 
         SECTION("Using a valid empty-namespace function within a ClientConfig object")
         {
             ClientConfig config{accountId, instanceId, nameSpace, TestLoggingCallback};
-            REQUIRE(SFSClient::Make(config, sfsClient) == Result::S_Ok);
+            REQUIRE(SFSClient::Make(config, sfsClient) == Result::Success);
             REQUIRE(sfsClient != nullptr);
         }
 
         SECTION("Using a valid static function within a ClientConfig object")
         {
             ClientConfig config{accountId, instanceId, nameSpace, StaticTestLoggingCallback};
-            REQUIRE(SFSClient::Make(config, sfsClient) == Result::S_Ok);
+            REQUIRE(SFSClient::Make(config, sfsClient) == Result::Success);
             REQUIRE(sfsClient != nullptr);
         }
 
         SECTION("Using a valid static member method within a ClientConfig object")
         {
             ClientConfig config{accountId, instanceId, nameSpace, &TestLoggingCallbackStruct::TestLoggingCallback};
-            REQUIRE(SFSClient::Make(config, sfsClient) == Result::S_Ok);
+            REQUIRE(SFSClient::Make(config, sfsClient) == Result::Success);
             REQUIRE(sfsClient != nullptr);
         }
 
         SECTION("Can also move a lambda")
         {
             ClientConfig config{accountId, instanceId, nameSpace, [](const LogData&) {}};
-            REQUIRE(SFSClient::Make(std::move(config), sfsClient) == Result::S_Ok);
+            REQUIRE(SFSClient::Make(std::move(config), sfsClient) == Result::Success);
             REQUIRE(sfsClient != nullptr);
         }
     }
 
     SECTION("AccountId cannot be empty")
     {
-        REQUIRE(SFSClient::Make({}, sfsClient) == Result::E_InvalidArg);
+        REQUIRE(SFSClient::Make({}, sfsClient) == Result::InvalidArg);
         REQUIRE(sfsClient == nullptr);
 
         ClientConfig config;
-        REQUIRE(SFSClient::Make(config, sfsClient) == Result::E_InvalidArg);
+        REQUIRE(SFSClient::Make(config, sfsClient) == Result::InvalidArg);
         REQUIRE(sfsClient == nullptr);
 
         config = {};
-        REQUIRE(SFSClient::Make(config, sfsClient) == Result::E_InvalidArg);
+        REQUIRE(SFSClient::Make(config, sfsClient) == Result::InvalidArg);
         REQUIRE(sfsClient == nullptr);
 
         config.accountId = std::string();
-        REQUIRE(SFSClient::Make(config, sfsClient) == Result::E_InvalidArg);
+        REQUIRE(SFSClient::Make(config, sfsClient) == Result::InvalidArg);
         REQUIRE(sfsClient == nullptr);
 
         config.instanceId = instanceId;
-        REQUIRE(SFSClient::Make(config, sfsClient) == Result::E_InvalidArg);
+        REQUIRE(SFSClient::Make(config, sfsClient) == Result::InvalidArg);
         REQUIRE(sfsClient == nullptr);
     }
 
@@ -209,7 +209,7 @@ TEST_SCENARIO("Testing SFSClient::GetLatestDownloadInfo()")
         THEN("SFSClient::GetLatestDownloadInfo() is not implemented")
         {
             Contents contents;
-            REQUIRE(sfsClient->GetLatestDownloadInfo("productName", contents) == Result::E_NotImpl);
+            REQUIRE(sfsClient->GetLatestDownloadInfo("productName", contents) == Result::NotImpl);
         }
     }
 }
@@ -225,7 +225,7 @@ TEST_SCENARIO("Testing SFSClient::GetLatestDownloadInfoWithAttributes()")
             const SearchAttributes attributes{{"attr1", "value"}};
 
             Contents contents;
-            REQUIRE(sfsClient->GetLatestDownloadInfo("productName", attributes, contents) == Result::E_NotImpl);
+            REQUIRE(sfsClient->GetLatestDownloadInfo("productName", attributes, contents) == Result::NotImpl);
         }
     }
 }
@@ -241,11 +241,11 @@ TEST_SCENARIO("Testing SFSClient::GetDeliveryOptimizationData()")
             const SearchAttributes attributes{{"attr1", "value"}};
 
             Contents contents;
-            REQUIRE(sfsClient->GetLatestDownloadInfo("productName", attributes, contents) == Result::E_NotImpl);
+            REQUIRE(sfsClient->GetLatestDownloadInfo("productName", attributes, contents) == Result::NotImpl);
 
             std::unique_ptr<Content> content;
             std::unique_ptr<DeliveryOptimizationData> data;
-            REQUIRE(sfsClient->GetDeliveryOptimizationData(*content, data) == Result::E_NotImpl);
+            REQUIRE(sfsClient->GetDeliveryOptimizationData(*content, data) == Result::NotImpl);
         }
     }
 }
@@ -261,11 +261,11 @@ TEST_SCENARIO("Testing SFSClient::GetApplicabilityDetails()")
             const SearchAttributes attributes{{"attr1", "value"}};
 
             Contents contents;
-            REQUIRE(sfsClient->GetLatestDownloadInfo("productName", attributes, contents) == Result::E_NotImpl);
+            REQUIRE(sfsClient->GetLatestDownloadInfo("productName", attributes, contents) == Result::NotImpl);
 
             std::unique_ptr<Content> content;
             std::unique_ptr<ApplicabilityDetails> details;
-            REQUIRE(sfsClient->GetApplicabilityDetails(*content, details) == Result::E_NotImpl);
+            REQUIRE(sfsClient->GetApplicabilityDetails(*content, details) == Result::NotImpl);
         }
     }
 }

--- a/client/tests/unit/details/CurlConnectionTests.cpp
+++ b/client/tests/unit/details/CurlConnectionTests.cpp
@@ -30,7 +30,7 @@ class MockCurlConnection : public CurlConnection
   protected:
     [[nodiscard]] Result CurlPerform(const std::string&, std::string& response) override
     {
-        if (m_responseCode == Result::S_Ok)
+        if (m_responseCode == Result::Success)
         {
             response = m_response;
         }
@@ -47,7 +47,7 @@ TEST("Testing CurlConnection()")
 {
     ReportingHandler handler;
     handler.SetLoggingCallback(LogCallbackToTest);
-    Result::Code responseCode = Result::E_HttpNotFound;
+    Result::Code responseCode = Result::HttpNotFound;
     std::string response = "expected";
     std::unique_ptr<Connection> connection = std::make_unique<MockCurlConnection>(handler, responseCode, response);
 
@@ -57,7 +57,7 @@ TEST("Testing CurlConnection()")
         REQUIRE(connection->Get("url", out) == responseCode);
         REQUIRE(out.empty());
 
-        responseCode = Result::S_Ok;
+        responseCode = Result::Success;
         REQUIRE(connection->Get("url", out) == responseCode);
         REQUIRE(out == response);
     }
@@ -72,7 +72,7 @@ TEST("Testing CurlConnection()")
         REQUIRE(connection->Post("url", body.dump(), out) == responseCode);
         REQUIRE(out.empty());
 
-        responseCode = Result::S_Ok;
+        responseCode = Result::Success;
         REQUIRE(connection->Get("url", out) == responseCode);
         REQUIRE(out == response);
 

--- a/client/tests/unit/details/ErrorHandlingTests.cpp
+++ b/client/tests/unit/details/ErrorHandlingTests.cpp
@@ -37,7 +37,7 @@ try
 }
 SFS_CATCH_RETURN();
 
-Result TestSFS_ReturnIfFailed(const Result& result, const Result& ifNotFailed = Result::S_Ok)
+Result TestSFS_ReturnIfFailed(const Result& result, const Result& ifNotFailed = Result::Success)
 {
     RETURN_IF_FAILED(result);
     return ifNotFailed;
@@ -46,21 +46,21 @@ Result TestSFS_ReturnIfFailed(const Result& result, const Result& ifNotFailed = 
 
 TEST("Testing ErrorHandling's SFS_CATCH_RETURN()")
 {
-    REQUIRE(TestSFS_Catch_Return_bad_alloc() == Result::E_OutOfMemory);
-    REQUIRE(TestSFS_Catch_Return_std_exception() == Result::E_Unexpected);
-    REQUIRE(TestSFS_Catch_Return_unknown() == Result::E_Unexpected);
+    REQUIRE(TestSFS_Catch_Return_bad_alloc() == Result::OutOfMemory);
+    REQUIRE(TestSFS_Catch_Return_std_exception() == Result::Unexpected);
+    REQUIRE(TestSFS_Catch_Return_unknown() == Result::Unexpected);
 }
 
 TEST("Testing ErrorHandling's RETURN_IF_FAILED()")
 {
     SECTION("Test that RETURN_IF_FAILED returns the result if it is a failure")
     {
-        REQUIRE(TestSFS_ReturnIfFailed(Result::Code::E_Unexpected) == Result::Code::E_Unexpected);
+        REQUIRE(TestSFS_ReturnIfFailed(Result::Code::Unexpected) == Result::Code::Unexpected);
     }
 
     SECTION("Test that RETURN_IF_FAILED does not return if the result is a success")
     {
-        REQUIRE(TestSFS_ReturnIfFailed(Result::Code::S_Ok) == Result::Code::S_Ok);
-        REQUIRE(TestSFS_ReturnIfFailed(Result::Code::S_Ok, Result::Code::E_Unexpected) == Result::Code::E_Unexpected);
+        REQUIRE(TestSFS_ReturnIfFailed(Result::Code::Success) == Result::Code::Success);
+        REQUIRE(TestSFS_ReturnIfFailed(Result::Code::Success, Result::Code::Unexpected) == Result::Code::Unexpected);
     }
 }

--- a/client/tests/unit/details/SFSClientImplTests.cpp
+++ b/client/tests/unit/details/SFSClientImplTests.cpp
@@ -23,32 +23,32 @@ TEST("Testing class SFSClientImpl()")
     SECTION("Testing SFSClientImpl::GetLatestVersion()")
     {
         std::unique_ptr<VersionResponse> response;
-        REQUIRE(sfsClient.GetLatestVersion("productName", std::nullopt, *connection, response) == Result::E_NotImpl);
+        REQUIRE(sfsClient.GetLatestVersion("productName", std::nullopt, *connection, response) == Result::NotImpl);
 
         const SearchAttributes attributes{{"attr1", "value"}};
-        REQUIRE(sfsClient.GetLatestVersion("productName", attributes, *connection, response) == Result::E_NotImpl);
+        REQUIRE(sfsClient.GetLatestVersion("productName", attributes, *connection, response) == Result::NotImpl);
     }
 
     SECTION("Testing SFSClientImpl::GetSpecificVersion()")
     {
         std::unique_ptr<VersionResponse> response;
         REQUIRE(sfsClient.GetSpecificVersion("productName", "version", std::nullopt, *connection, response) ==
-                Result::E_NotImpl);
+                Result::NotImpl);
 
         const SearchAttributes attributes{{"attr1", "value"}};
         REQUIRE(sfsClient.GetSpecificVersion("productName", "version", attributes, *connection, response) ==
-                Result::E_NotImpl);
+                Result::NotImpl);
     }
 
     SECTION("Testing SFSClientImpl::GetDownloadInfo()")
     {
         std::unique_ptr<DownloadInfoResponse> response;
         REQUIRE(sfsClient.GetDownloadInfo("productName", "version", std::nullopt, *connection, response) ==
-                Result::E_NotImpl);
+                Result::NotImpl);
 
         const SearchAttributes attributes{{"attr1", "value"}};
         REQUIRE(sfsClient.GetDownloadInfo("productName", "version", attributes, *connection, response) ==
-                Result::E_NotImpl);
+                Result::NotImpl);
     }
 }
 


### PR DESCRIPTION
Closes #30

Removing E_ and S_ prefix from error codes as a stylistic request.
Renaming S_Ok to Success.