### PR TITLE
Updating versions of GitGub actions for the ubuntu build due to node deprecation warning

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up required environment variables for vcpkg cache
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');


### PR DESCRIPTION
Missed doing what I did in #37 when I added the Ubuntu build.

> Seeing following warning on GitHub actions page
>
> ![image](https://github.com/microsoft/sfs-client/assets/153530493/afb994e4-db07-4098-8f81-ac84c5f338c0 "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/github-script@v6, actions/cache@v3.3.2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/")
>
> So I'm updating the actions we use to the latest available