### PR TITLE
Fixing remaining comments on ErrorHandling macros

### DIFF
--- a/client/src/details/ErrorHandling.cpp
+++ b/client/src/details/ErrorHandling.cpp
@@ -7,15 +7,15 @@
 
 using namespace SFS::details;
 
-void SFS::details::LogFailedResult(const ReportingHandler& handler,
-                                   const SFS::Result& result,
+void SFS::details::LogFailedResult(const SFS::Result& result,
+                                   const ReportingHandler& handler,
                                    const char* file,
-                                   int line)
+                                   unsigned line)
 {
     if (result.IsFailure())
     {
         LOG_ERROR(handler,
-                  "FAILED [%s] %s%s(%s:%d)",
+                  "FAILED [%s] %s%s(%s:%u)",
                   std::string(ToString(result.GetCode())).c_str(),
                   result.GetMessage().c_str(),
                   result.GetMessage().empty() ? "" : " ",
@@ -24,26 +24,26 @@ void SFS::details::LogFailedResult(const ReportingHandler& handler,
     }
 }
 
-void SFS::details::LogIfFailed(const Result& result, const ReportingHandler& handler, const char* file, int line)
+void SFS::details::LogIfFailed(const Result& result, const ReportingHandler& handler, const char* file, unsigned line)
 {
     if (result.IsFailure())
     {
-        LogFailedResult(handler, result, file, line);
+        LogFailedResult(result, handler, file, line);
     }
 }
 
-void SFS::details::ThrowLog(Result result, const ReportingHandler& handler, const char* file, int line)
+void SFS::details::ThrowLog(Result result, const ReportingHandler& handler, const char* file, unsigned line)
 {
     assert(result.IsFailure());
-    LogFailedResult(handler, result, file, line);
+    LogFailedResult(result, handler, file, line);
     throw SFSException(std::move(result));
 }
 
-void SFS::details::ThrowIfFailedLog(Result result, const ReportingHandler& handler, const char* file, int line)
+void SFS::details::ThrowIfFailedLog(Result result, const ReportingHandler& handler, const char* file, unsigned line)
 {
     if (result.IsFailure())
     {
-        LogFailedResult(handler, result, file, line);
+        LogFailedResult(result, handler, file, line);
         throw SFSException(std::move(result));
     }
 }
@@ -62,14 +62,14 @@ void SFS::details::ThrowCodeIfLog(Result::Code code,
                                   bool condition,
                                   const ReportingHandler& handler,
                                   const char* file,
-                                  int line,
+                                  unsigned line,
                                   std::string message)
 {
     if (condition)
     {
         Result result(code, std::move(message));
         assert(result.IsFailure());
-        LogFailedResult(handler, result, file, line);
+        LogFailedResult(result, handler, file, line);
         throw SFSException(std::move(result));
     }
 }

--- a/client/src/details/ErrorHandling.h
+++ b/client/src/details/ErrorHandling.h
@@ -29,7 +29,7 @@
 #define SFS_CATCH_LOG_RETHROW(handler)                                                                                 \
     catch (const SFS::details::SFSException& e)                                                                        \
     {                                                                                                                  \
-        SFS::details::LogFailedResult(handler, e.GetResult(), __FILE__, __LINE__);                                     \
+        SFS::details::LogFailedResult(e.GetResult(), handler, __FILE__, __LINE__);                                     \
         throw;                                                                                                         \
     }
 
@@ -49,7 +49,7 @@
         auto __result = (result); /* Assigning to a variable ensures a code block gets called only once */             \
         if (__result.IsFailure())                                                                                      \
         {                                                                                                              \
-            SFS::details::LogFailedResult(handler, __result, __FILE__, __LINE__);                                      \
+            SFS::details::LogFailedResult(__result, handler, __FILE__, __LINE__);                                      \
             return __result;                                                                                           \
         }                                                                                                              \
     } while ((void)0, 0)
@@ -69,16 +69,16 @@ namespace SFS::details
 {
 class ReportingHandler;
 
-void LogFailedResult(const ReportingHandler& handler, const Result& result, const char* file, int line);
-void LogIfFailed(const Result& result, const ReportingHandler& handler, const char* file, int line);
+void LogFailedResult(const Result& result, const ReportingHandler& handler, const char* file, unsigned line);
+void LogIfFailed(const Result& result, const ReportingHandler& handler, const char* file, unsigned line);
 
-void ThrowLog(Result result, const ReportingHandler& handler, const char* file, int line);
-void ThrowIfFailedLog(Result result, const ReportingHandler& handler, const char* file, int line);
+void ThrowLog(Result result, const ReportingHandler& handler, const char* file, unsigned line);
+void ThrowIfFailedLog(Result result, const ReportingHandler& handler, const char* file, unsigned line);
 void ThrowCodeIf(Result::Code code, bool condition, std::string message = {});
 void ThrowCodeIfLog(Result::Code code,
                     bool condition,
                     const ReportingHandler& handler,
                     const char* file,
-                    int line,
+                    unsigned line,
                     std::string message = {});
 } // namespace SFS::details


### PR DESCRIPTION
Helps #43

Fixing comments made on https://github.com/microsoft/sfs-client/commit/9a8b44557280bba4ac545115058388db4f654d60 from #87

int -> unsigned
making arguments of Log* functions consistently ordered