### PR TITLE
Migrating Azure pipeline to 1ES template

### DIFF
--- a/azure-pipelines/build/build-windows.yml
+++ b/azure-pipelines/build/build-windows.yml
@@ -6,31 +6,48 @@ trigger:
 pr:
 - main
 
-pool:
-  vmImage: "windows-2022"
+resources:
+  repositories:
+  - repository: onebranchTemplates
+    type: git
+    name: OneBranch.Pipelines/GovernedTemplates
+    ref: refs/heads/main
 
-jobs:
-- job: windowsBuild
+variables:
+- name: WindowsContainerImage
+  value: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
 
-  steps:
-    - checkout: self
+extends:
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
+  parameters:
+    stages:
+    - stage: stage
+      jobs:
+      - job: windowsBuild
+        pool:
+          type: windows
 
-    - template: templates/install-winget.yml
+        variables:
+        - name: ob_outputDirectory
+          value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
 
-    - task: PowerShell@2
-      displayName: Setup
-      inputs:
-        targetType: 'inline'
-        script: .\scripts\Setup.ps1 -NoBuildTools
+        steps:
+        - checkout: self
+        - template: /azure-pipelines/build/templates/install-winget.yml@self
+        - task: PowerShell@2
+          displayName: Setup
+          inputs:
+            targetType: 'inline'
+            script: .\scripts\Setup.ps1 -NoBuildTools
 
-    - task: PowerShell@2
-      displayName: Build
-      inputs:
-        targetType: 'inline'
-        script: .\scripts\Build.ps1
+        - task: PowerShell@2
+          displayName: Build
+          inputs:
+            targetType: 'inline'
+            script: .\scripts\Build.ps1
 
-    - task: PowerShell@2
-      displayName: Test
-      inputs:
-        targetType: 'inline'
-        script: .\scripts\Test.ps1 -OutputOnFailure
+        - task: PowerShell@2
+          displayName: Test
+          inputs:
+            targetType: 'inline'
+            script: .\scripts\Test.ps1 -OutputOnFailure


### PR DESCRIPTION
The pipeline needs to be "governed", which means it must extend from OneBranch templates.

Ran the automatic conversion tool and it added a few lines to the pipeline.
Also simplified the trigger rules.