### PR TITLE
Updating dependencies of install-winget action

### DIFF
--- a/.github/workflows/install-winget/action.yml
+++ b/.github/workflows/install-winget/action.yml
@@ -34,7 +34,7 @@ runs:
           if (!(Test-Path $WingetInstaller))
           {
             Write-Host "Downloading Winget"
-            Invoke-WebRequest -Uri https://aka.ms/getwinget -OutFile $WingetInstaller
+            Invoke-WebRequest -Uri https://github.com/microsoft/winget-cli/releases/download/v1.7.10582/$WingetInstaller -OutFile $WingetInstaller
           }
           $VCLibsInstaller = "Microsoft.VCLibs.x64.14.00.Desktop.appx"
           if (!(Test-Path $VCLibsInstaller))

--- a/azure-pipelines/build/templates/install-winget.yml
+++ b/azure-pipelines/build/templates/install-winget.yml
@@ -28,7 +28,7 @@ steps:
         if (!(Test-Path $WingetInstaller))
         {
           Write-Host "Downloading Winget"
-          Invoke-WebRequest -Uri https://aka.ms/getwinget -OutFile $WingetInstaller
+          Invoke-WebRequest -Uri https://github.com/microsoft/winget-cli/releases/download/v1.7.10582/$WingetInstaller -OutFile $WingetInstaller
         }
         $VCLibsInstaller = "Microsoft.VCLibs.x64.14.00.Desktop.appx"
         if (!(Test-Path $VCLibsInstaller))


### PR DESCRIPTION
Closes #109

Looks like the latest winget now requires XAML 2.8.6. It never failed for us because of the winget cache, but is failing on uncached pipelines.
I am also fixing the winget version to make the builds reproducible and not change due to an update in a "latest" version.