### PR TITLE
Renaming Result::GetMessage to GetMsg due to Windows API conflicts

### DIFF
--- a/client/include/sfsclient/Result.h
+++ b/client/include/sfsclient/Result.h
@@ -37,7 +37,10 @@ class Result
     Result(Code code, std::string message) noexcept;
 
     Code GetCode() const noexcept;
-    const std::string& GetMessage() const noexcept;
+
+    /// @brief Returns the message associated with the result code.
+    /// @note "GetMsg" is used instead of "GetMessage" to avoid conflicts with Windows API.
+    const std::string& GetMsg() const noexcept;
 
     bool IsSuccess() const noexcept;
     bool IsFailure() const noexcept;

--- a/client/src/Result.cpp
+++ b/client/src/Result.cpp
@@ -28,7 +28,7 @@ Result::Code Result::GetCode() const noexcept
     return m_code;
 }
 
-const std::string& Result::GetMessage() const noexcept
+const std::string& Result::GetMsg() const noexcept
 {
     return m_message;
 }

--- a/client/src/details/ErrorHandling.cpp
+++ b/client/src/details/ErrorHandling.cpp
@@ -17,8 +17,8 @@ void SFS::details::LogFailedResult(const SFS::Result& result,
         LOG_ERROR(handler,
                   "FAILED [%s] %s%s(%s:%u)",
                   std::string(ToString(result.GetCode())).c_str(),
-                  result.GetMessage().c_str(),
-                  result.GetMessage().empty() ? "" : " ",
+                  result.GetMsg().c_str(),
+                  result.GetMsg().empty() ? "" : " ",
                   file,
                   line);
     }

--- a/client/src/details/SFSException.cpp
+++ b/client/src/details/SFSException.cpp
@@ -24,5 +24,5 @@ const SFS::Result& SFSException::GetResult() const noexcept
 
 const char* SFSException::what() const noexcept
 {
-    return m_result.GetMessage().c_str();
+    return m_result.GetMsg().c_str();
 }

--- a/client/tests/functional/details/CurlConnectionTests.cpp
+++ b/client/tests/functional/details/CurlConnectionTests.cpp
@@ -21,9 +21,6 @@
 
 #define TEST(...) TEST_CASE("[Functional][CurlConnectionTests] " __VA_ARGS__)
 
-// Define included by Win32 headers
-#undef GetMessage
-
 using namespace SFS;
 using namespace SFS::details;
 using namespace SFS::test;

--- a/client/tests/unit/ResultTests.cpp
+++ b/client/tests/unit/ResultTests.cpp
@@ -16,7 +16,7 @@ TEST("Testing Result() class methods")
         Result resultSuccess(Result::Code::Success);
 
         REQUIRE(resultSuccess.GetCode() == Result::Code::Success);
-        REQUIRE(resultSuccess.GetMessage().empty());
+        REQUIRE(resultSuccess.GetMsg().empty());
         REQUIRE(resultSuccess.IsSuccess());
         REQUIRE_FALSE(resultSuccess.IsFailure());
 
@@ -35,7 +35,7 @@ TEST("Testing Result() class methods")
     {
         Result resultUnexpected(Result::Code::Unexpected, "message");
         REQUIRE(resultUnexpected.GetCode() == Result::Code::Unexpected);
-        REQUIRE(resultUnexpected.GetMessage() == "message");
+        REQUIRE(resultUnexpected.GetMsg() == "message");
         REQUIRE_FALSE(resultUnexpected.IsSuccess());
         REQUIRE(resultUnexpected.IsFailure());
 

--- a/client/tests/unit/SFSClientTests.cpp
+++ b/client/tests/unit/SFSClientTests.cpp
@@ -211,14 +211,14 @@ TEST("Testing SFSClient::GetLatestDownloadInfo()")
         params.productRequests = {{"", {}}};
         auto result = sfsClient->GetLatestDownloadInfo(params, content);
         REQUIRE(result.GetCode() == Result::InvalidArg);
-        REQUIRE(result.GetMessage() == "product cannot be empty");
+        REQUIRE(result.GetMsg() == "product cannot be empty");
         REQUIRE(content == nullptr);
 
         const TargetingAttributes attributes{{"attr1", "value"}};
         params.productRequests = {{"", attributes}};
         result = sfsClient->GetLatestDownloadInfo(params, content);
         REQUIRE(result.GetCode() == Result::InvalidArg);
-        REQUIRE(result.GetMessage() == "product cannot be empty");
+        REQUIRE(result.GetMsg() == "product cannot be empty");
         REQUIRE(content == nullptr);
     }
 
@@ -226,7 +226,7 @@ TEST("Testing SFSClient::GetLatestDownloadInfo()")
     {
         auto result = sfsClient->GetLatestDownloadInfo(params, content);
         REQUIRE(result.GetCode() == Result::InvalidArg);
-        REQUIRE(result.GetMessage() == "productRequests cannot be empty");
+        REQUIRE(result.GetMsg() == "productRequests cannot be empty");
         REQUIRE(content == nullptr);
     }
 
@@ -235,7 +235,7 @@ TEST("Testing SFSClient::GetLatestDownloadInfo()")
         params.productRequests = {{"p1", {}}, {"p2", {}}};
         auto result = sfsClient->GetLatestDownloadInfo(params, content);
         REQUIRE(result.GetCode() == Result::NotImpl);
-        REQUIRE(result.GetMessage() == "There cannot be more than 1 productRequest at the moment");
+        REQUIRE(result.GetMsg() == "There cannot be more than 1 productRequest at the moment");
         REQUIRE(content == nullptr);
     }
 
@@ -245,13 +245,13 @@ TEST("Testing SFSClient::GetLatestDownloadInfo()")
         params.baseCV = "";
         auto result = sfsClient->GetLatestDownloadInfo(params, content);
         REQUIRE(result.GetCode() == Result::InvalidArg);
-        REQUIRE(result.GetMessage() == "cv must not be empty");
+        REQUIRE(result.GetMsg() == "cv must not be empty");
         REQUIRE(content == nullptr);
 
         params.baseCV = "cv";
         result = sfsClient->GetLatestDownloadInfo(params, content);
         REQUIRE(result.GetCode() == Result::InvalidArg);
-        REQUIRE(result.GetMessage().find("baseCV is not a valid correlation vector:") == 0);
+        REQUIRE(result.GetMsg().find("baseCV is not a valid correlation vector:") == 0);
         REQUIRE(content == nullptr);
     }
 }

--- a/tool/SFSClientTool.cpp
+++ b/tool/SFSClientTool.cpp
@@ -198,9 +198,9 @@ void DisplayResults(const std::unique_ptr<Content>& content)
 void LogResult(const SFS::Result& result)
 {
     std::cout << "  Result code: " << ToString(result.GetCode());
-    if (!result.GetMessage().empty())
+    if (!result.GetMsg().empty())
     {
-        std::cout << ". Message: " << result.GetMessage();
+        std::cout << ". Message: " << result.GetMsg();
     }
     std::cout << std::endl;
 }


### PR DESCRIPTION
Closes #107