### PR TITLE
Fixing issues in Setup.ps1 script

### DIFF
--- a/scripts/Setup.ps1
+++ b/scripts/Setup.ps1
@@ -33,7 +33,7 @@ function Install-Python {
     if (!$?) {
         winget install python
         if (!$?) {
-            Write-Host "Failed to install Python"
+            Write-Host -ForegroundColor Red "Failed to install Python"
             exit 1
         }
     }
@@ -60,7 +60,7 @@ function Install-CMake {
     catch {
         winget install cmake
         if (!$?) {
-            Write-Host "Failed to install cmake"
+            Write-Host -ForegroundColor Red "Failed to install cmake"
             exit 1
         }
 
@@ -81,7 +81,7 @@ function Install-CppBuildTools {
     # --wait makes the install synchronous
     winget install Microsoft.VisualStudio.2022.BuildTools --silent --override "--wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --remove Microsoft.VisualStudio.Component.VC.CMake.Project"
     if (!$?) {
-        Write-Host "Failed to install build tools"
+        Write-Host -ForegroundColor Red "Failed to install build tools"
         exit 1
     }
 }


### PR DESCRIPTION
Closes #122

Ran this on a new VM to check for issues.

1. `cmake --version` check was still outputting error on the console even with the out-null redirection. Switched to a try-catch which fixes it.
2. Stopping on errors instead of continuing a failed script
3. Removing `--add productLang` override on the vc tools installation which is not working on some devices and is not required for the installation
