### PR TITLE
Choosing OpenSSL explicitly for curl

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -55,6 +55,25 @@
       "component": {
         "type": "git",
         "git": {
+          "repositoryUrl": "https://github.com/openssl/openssl",
+          "commitHash": "01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      },
+      "developmentDependency": false,
+      "dependencyRoots": [
+        {
+          "type": "git",
+          "git": {
+            "repositoryUrl": "https://github.com/curl/curl",
+            "commitHash": "d755a5f7c009dd63a61b2c745180d8ba937cbfeb"
+          }
+        }
+      ]
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
           "repositoryUrl": "https://github.com/microsoft/do-client",
           "commitHash": "d71ade6f692dd8bc319ec3228c956517e9b29292"
         }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,12 +7,17 @@
     {
       "name": "curl",
       "features": [
-        "c-ares"
+        "c-ares",
+        "openssl"
       ]
     },
     "nlohmann-json"
   ],
   "overrides": [
+    {
+      "name": "c-ares",
+      "version": "1.19.1"
+    },
     {
       "name": "catch2",
       "version": "3.4.0"
@@ -28,6 +33,10 @@
     {
       "name": "nlohmann-json",
       "version": "3.11.3"
+    },
+    {
+      "name": "openssl",
+      "version": "3.1.4#1"
     }
   ],
   "vcpkg-configuration": {


### PR DESCRIPTION
Helps #42

Finalizing planned dependencies to create the NOTICE file.
Choosing OpenSSL as an explicit feature in vcpkg, which will be the same TLS backend for all platforms.

https://curl.se/docs/ssl-compared.html

Also fixed c-ares version in vcpkg.