### PR TITLE
Renaming CMake project SFSClient to sfsclient

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 set(SFS_LIBRARY_VERSION "0.1.0")
 
 project(
-    SFSClient
+    sfsclient
     VERSION ${SFS_LIBRARY_VERSION}
     LANGUAGES CXX)
 


### PR DESCRIPTION
Closes #144

Move to lowercase naming to keep up with other cmake and vcpkg projects, and also to mimic the include folder sfsclient.