### PR TITLE
Removing SFSClient::GetApplicabilityDetails()

### DIFF
--- a/client/include/sfsclient/SFSClient.h
+++ b/client/include/sfsclient/SFSClient.h
@@ -16,8 +16,6 @@
 
 namespace SFS
 {
-class ApplicabilityDetails;
-
 namespace details
 {
 class SFSClientInterface;
@@ -55,20 +53,6 @@ class SFSClient
      */
     [[nodiscard]] Result GetLatestDownloadInfo(const RequestParams& requestParams,
                                                std::unique_ptr<Content>& content) const noexcept;
-
-    //
-    // API to retrieve optional extra download information from the SFS Service
-    //
-
-    /**
-     * @brief Retrieve Applicability details for a given piece of content, if existing
-     * @details If the Applicability details are not available, the result code will be set to Result::NotSet
-     * and the param details will not be modified
-     * @param content A content object that was returned from a previous call to GetDownloadInfo
-     * @param data A ApplicabilityDetails object that is populated with the result
-     */
-    [[nodiscard]] Result GetApplicabilityDetails(const Content& content,
-                                                 std::unique_ptr<ApplicabilityDetails>& details) const noexcept;
 
     /**
      * @return The version of the SFSClient library

--- a/client/src/SFSClient.cpp
+++ b/client/src/SFSClient.cpp
@@ -84,16 +84,6 @@ try
 }
 SFS_CATCH_RETURN()
 
-Result SFSClient::GetApplicabilityDetails(
-    [[maybe_unused]] const Content& content,
-    [[maybe_unused]] std::unique_ptr<ApplicabilityDetails>& details) const noexcept
-try
-{
-    // return m_impl->GetApplicabilityDetails(...);
-    return Result::NotImpl;
-}
-SFS_CATCH_RETURN()
-
 const char* SFSClient::GetVersion() noexcept
 {
 #ifdef SFS_GIT_INFO

--- a/client/tests/unit/SFSClientTests.cpp
+++ b/client/tests/unit/SFSClientTests.cpp
@@ -254,20 +254,3 @@ TEST("Testing SFSClient::GetLatestDownloadInfo()")
         REQUIRE(content == nullptr);
     }
 }
-
-TEST_SCENARIO("Testing SFSClient::GetApplicabilityDetails()")
-{
-    GIVEN("An SFSClient")
-    {
-        auto sfsClient = GetSFSClient();
-
-        THEN("SFSClient::GetApplicabilityDetails() is not implemented")
-        {
-            const TargetingAttributes attributes{{"attr1", "value"}};
-
-            std::unique_ptr<Content> content;
-            std::unique_ptr<ApplicabilityDetails> details;
-            REQUIRE(sfsClient->GetApplicabilityDetails(*content, details) == Result::NotImpl);
-        }
-    }
-}


### PR DESCRIPTION
Helps #50

Method will no longer be needed since we'll provide AppContent directly.