### PR TITLE
Adding MockWebServer::RegisterAppProduct()

### DIFF
--- a/client/tests/mock/MockWebServer.h
+++ b/client/tests/mock/MockWebServer.h
@@ -25,6 +25,12 @@ class MockWebServerImpl;
 using HttpCode = int;
 using HeaderMap = std::unordered_map<std::string, std::string>;
 
+struct MockPrerequisite
+{
+    std::string name;
+    std::string version;
+};
+
 class MockWebServer
 {
   public:
@@ -40,6 +46,9 @@ class MockWebServer
 
     /// @brief Registers a product with the server. Will fill the other data with gibberish for testing purposes
     void RegisterProduct(std::string name, std::string version);
+
+    /// @brief Registers an app with the server. Will fill the other data with gibberish for testing purposes
+    void RegisterAppProduct(std::string name, std::string version, std::vector<MockPrerequisite> prerequisites);
 
     /// @brief Registers the expectation of a given header to the present in the request
     void RegisterExpectedRequestHeader(SFS::details::HttpHeader header, std::string value);


### PR DESCRIPTION
Helps #50

Allows one to add a mock app to the mock web server.
It adds a new list of apps
Server first searches on the generic product list, and then in the app product list if it does not find a product.
No guardrails for duplicate names yet, that is not the purpose for which this will be used.
Prerequisites get registered as well, since the SFS flow is to get content for main app and all prerequisites.
Most comment is filled with gibberish just to simulate a server response.