### PR TITLE
Moving SFSClientTool to samples folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,6 @@ if(MSVC)
 endif()
 
 add_subdirectory(client)
-add_subdirectory(tool)
 
 if(SFS_BUILD_SAMPLES)
     add_subdirectory(samples)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -2,3 +2,4 @@
 # Licensed under the MIT License.
 
 add_subdirectory(integration-do-client)
+add_subdirectory(tool)

--- a/samples/tool/CMakeLists.txt
+++ b/samples/tool/CMakeLists.txt
@@ -16,6 +16,6 @@ add_dependencies(${PROJECT_NAME} ${SFS_CLIENT_LIB_NAME})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${SFS_CLIENT_LIB_NAME})
 target_link_libraries(${PROJECT_NAME} PRIVATE nlohmann_json::nlohmann_json)
 
-target_include_directories(${PROJECT_NAME} PUBLIC ../client/include)
+target_include_directories(${PROJECT_NAME} PUBLIC ../../client/include)
 
 set_compile_options_for_target(${PROJECT_NAME})

--- a/samples/tool/SFSClientTool.cpp
+++ b/samples/tool/SFSClientTool.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include "sfsclient/SFSClient.h"
+#include <sfsclient/SFSClient.h>
 
 #include <exception>
 #include <filesystem>


### PR DESCRIPTION
Closes #145

> Move tool to samples folder since it's not a default product for end users.
It will then also be controlled by SFS_BUILD_SAMPLES.