### PR TITLE
Using Schannel for TLS in Windows for now while we don't have cert pinning

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,7 +16,11 @@
       "name": "curl",
       "features": [
         "c-ares",
-        "openssl"
+        {
+          "name": "openssl",
+          "platform": "!windows",
+          "$comment": "TODO #42: OpenSSL is not needed on Windows yet while we don't have cert pinning. Default is schannel, which uses Windows store"
+        }
       ]
     },
     "nlohmann-json"


### PR DESCRIPTION
Helps #42.

Moving to OpenSSL without a defined cert to pin to made usage with valid URLs start to fail, because OpenSSL does not look into the default Windows stores like Schannel does.
So keeping it like this until the cert pinning is finalized.
