### PR TITLE
Organizing Result codes in zones

### DIFF
--- a/client/include/sfsclient/Result.h
+++ b/client/include/sfsclient/Result.h
@@ -14,24 +14,38 @@ class Result
   public:
     enum Code : uint32_t
     {
-        // Represents a successful operation
         Success = 0x00000000,
-        // Represents a failed operation
-        ConnectionSetupFailed = 0x80000001,
-        ConnectionUnexpectedError = 0x80000002,
-        HttpBadRequest = 0x80000003,
-        HttpNotFound = 0x80000004,
-        HttpServiceNotAvailable = 0x80000005,
-        HttpTimeout = 0x80000006,
-        HttpTooManyRequests = 0x80000007,
-        HttpUnexpected = 0x80000008,
-        InvalidArg = 0x80000009,
-        NotImpl = 0x8000000A,
-        NotSet = 0x8000000B,
-        OutOfMemory = 0x8000000C,
-        ServiceInvalidResponse = 0x8000000D,
-        ServiceUnexpectedContentType = 0x8000000E,
-        Unexpected = 0x8000000F,
+
+        //
+        // Failure codes
+        //
+
+        // Generic errors start at 0x8000'0000
+        InvalidArg = 0x8000'0001,
+        NotImpl = 0x8000'0002,
+        NotSet = 0x8000'0003,
+        OutOfMemory = 0x8000'0004,
+        Unexpected = 0x8000'0005,
+
+        // Connection errors start at 0x8000'1000
+        ConnectionSetupFailed = 0x8000'1000,
+        ConnectionUnexpectedError = 0x8000'1001,
+
+        // Http Errors start at 0x8000'2000
+        // Generic Http errors
+        HttpTimeout = 0x8000'2000,
+        HttpUnexpected = 0x8000'2001,
+
+        // Last 3 digits mapped to Http status codes
+        HttpBadRequest = 0x8000'2400,
+        HttpNotFound = 0x8000'2404,
+        HttpMethodNotAllowed = 0x8000'2405,
+        HttpTooManyRequests = 0x8000'2429,
+        HttpServiceNotAvailable = 0x8000'2503,
+
+        // Service errors start at 0x8000'3000
+        ServiceInvalidResponse = 0x8000'3000,
+        ServiceUnexpectedContentType = 0x8000'3001,
     };
 
     Result(Code code) noexcept;

--- a/client/src/Result.cpp
+++ b/client/src/Result.cpp
@@ -62,26 +62,14 @@ std::string_view SFS::ToString(Result::Code code) noexcept
 {
     switch (code)
     {
-    // Represents a successful operation
     case Result::Success:
         return "Success";
-    // Represents a failed operation
-    case Result::ConnectionSetupFailed:
-        return "ConnectionSetupFailed";
-    case Result::ConnectionUnexpectedError:
-        return "ConnectionUnexpectedError";
-    case Result::HttpBadRequest:
-        return "HttpBadRequest";
-    case Result::HttpNotFound:
-        return "HttpNotFound";
-    case Result::HttpServiceNotAvailable:
-        return "HttpServiceNotAvailable";
-    case Result::HttpTimeout:
-        return "HttpTimeout";
-    case Result::HttpTooManyRequests:
-        return "HttpTooManyRequests";
-    case Result::HttpUnexpected:
-        return "HttpUnexpected";
+
+    //
+    // Failure codes
+    //
+
+    // Generic errors
     case Result::InvalidArg:
         return "InvalidArg";
     case Result::NotImpl:
@@ -90,12 +78,36 @@ std::string_view SFS::ToString(Result::Code code) noexcept
         return "NotSet";
     case Result::OutOfMemory:
         return "OutOfMemory";
+    case Result::Unexpected:
+        return "Unexpected";
+
+    // Connection errors
+    case Result::ConnectionSetupFailed:
+        return "ConnectionSetupFailed";
+    case Result::ConnectionUnexpectedError:
+        return "ConnectionUnexpectedError";
+
+    // Http Errors
+    case Result::HttpTimeout:
+        return "HttpTimeout";
+    case Result::HttpUnexpected:
+        return "HttpUnexpected";
+    case Result::HttpBadRequest:
+        return "HttpBadRequest";
+    case Result::HttpNotFound:
+        return "HttpNotFound";
+    case Result::HttpMethodNotAllowed:
+        return "HttpMethodNotAllowed";
+    case Result::HttpTooManyRequests:
+        return "HttpTooManyRequests";
+    case Result::HttpServiceNotAvailable:
+        return "HttpServiceNotAvailable";
+
+    // Service errors
     case Result::ServiceInvalidResponse:
         return "ServiceInvalidResponse";
     case Result::ServiceUnexpectedContentType:
         return "ServiceUnexpectedContentType";
-    case Result::Unexpected:
-        return "Unexpected";
     }
     return "";
 }

--- a/client/src/details/connection/CurlConnection.cpp
+++ b/client/src/details/connection/CurlConnection.cpp
@@ -144,7 +144,7 @@ Result HttpCodeToResult(long httpCode)
     }
     case 405:
     {
-        return Result(Result::HttpBadRequest, "405 Method Not Allowed");
+        return Result(Result::HttpMethodNotAllowed, "405 Method Not Allowed");
     }
     case 429:
     {


### PR DESCRIPTION
Closes #35

> You might want to establish "zones" for error codes so that adding new ones in future will still keep related errors grouped together. Example: 1-1024 can be generic errors like invalid arg, not impl, then the next set can be http errors and so on.

> Tip: Make all these match the HTTP code, e.g.
> HttpTooManyRequests = 0x8000'0000 + 429,