### PR TITLE
Removing windows static linkage restriction from cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@ set(CMAKE_TOOLCHAIN_FILE "vcpkg/scripts/buildsystems/vcpkg.cmake")
 
 # By default using x64 static custom triplet for Windows. Can be overridden by
 # setting VCPKG_TARGET_TRIPLET
-if(WIN32 AND NOT DEFINED VCPKG_TARGET_TRIPLET)
+if(SFS_WINDOWS_STATIC_ONLY
+   AND WIN32
+   AND NOT DEFINED VCPKG_TARGET_TRIPLET)
     set(VCPKG_TARGET_TRIPLET "x64-windows-static-custom")
 endif()
 
@@ -65,8 +67,8 @@ function(set_compile_options_for_target target)
     endif()
 endfunction()
 
-# For MSVC, use a multi-threaded statically-linked runtime library
-if(MSVC)
+if(SFS_WINDOWS_STATIC_ONLY AND MSVC)
+    # For MSVC, use a multi-threaded statically-linked runtime library
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 

--- a/cmake/SFSOptions.cmake
+++ b/cmake/SFSOptions.cmake
@@ -8,3 +8,8 @@ option(
     SFS_ENABLE_TEST_OVERRIDES
     "Set SFS_ENABLE_OVERRIDES to ON to enable certain test overrides through environment variables."
     OFF)
+
+option(
+    SFS_WINDOWS_STATIC_ONLY
+    "Indicates if only static libraries and dependencies should be built on Windows."
+    OFF)

--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -82,6 +82,7 @@ if (!(Test-Path $BuildFolder) -or $Regenerate)
     $Options = "-DSFS_ENABLE_TEST_OVERRIDES=$EnableTestOverridesStr";
     $Options += " -DSFS_BUILD_TESTS=$BuildTestsOverridesStr";
     $Options += " -DSFS_BUILD_SAMPLES=$BuildSamplesOverridesStr";
+    $Options += " -DSFS_WINDOWS_STATIC_ONLY=ON";
     Invoke-Expression "cmake -S $GitRoot -B $BuildFolder $Options"
 }
 


### PR DESCRIPTION
Helps #134

No longer making all builds restricted to static linkage. But adding option to do that, and using it in local build script.
Should help with vcpkg integration.