### PR TITLE
Validate request and config strings are not empty

### DIFF
--- a/client/src/details/SFSClientImpl.cpp
+++ b/client/src/details/SFSClientImpl.cpp
@@ -191,8 +191,7 @@ std::unique_ptr<VersionEntity> SFSClientImpl<ConnectionManagerT>::GetLatestVersi
 try
 {
     const auto& [product, attributes] = productRequest;
-    const std::string url{
-        SFSUrlComponents::GetLatestVersionUrl(GetBaseUrl(), m_instanceId, m_nameSpace, product, m_reportingHandler)};
+    const std::string url{SFSUrlComponents::GetLatestVersionUrl(GetBaseUrl(), m_instanceId, m_nameSpace, product)};
 
     LOG_INFO(m_reportingHandler, "Requesting latest version of [%s] from URL [%s]", product.c_str(), url.c_str());
 
@@ -217,8 +216,7 @@ VersionEntities SFSClientImpl<ConnectionManagerT>::GetLatestVersionBatch(
     Connection& connection) const
 try
 {
-    const std::string url{
-        SFSUrlComponents::GetLatestVersionBatchUrl(GetBaseUrl(), m_instanceId, m_nameSpace, m_reportingHandler)};
+    const std::string url{SFSUrlComponents::GetLatestVersionBatchUrl(GetBaseUrl(), m_instanceId, m_nameSpace)};
 
     LOG_INFO(m_reportingHandler, "Requesting latest version of multiple products from URL [%s]", url.c_str());
 
@@ -253,12 +251,8 @@ std::unique_ptr<VersionEntity> SFSClientImpl<ConnectionManagerT>::GetSpecificVer
                                                                                      Connection& connection) const
 try
 {
-    const std::string url{SFSUrlComponents::GetSpecificVersionUrl(GetBaseUrl(),
-                                                                  m_instanceId,
-                                                                  m_nameSpace,
-                                                                  product,
-                                                                  version,
-                                                                  m_reportingHandler)};
+    const std::string url{
+        SFSUrlComponents::GetSpecificVersionUrl(GetBaseUrl(), m_instanceId, m_nameSpace, product, version)};
 
     LOG_INFO(m_reportingHandler,
              "Requesting version [%s] of [%s] from URL [%s]",
@@ -287,12 +281,8 @@ FileEntities SFSClientImpl<ConnectionManagerT>::GetDownloadInfo(const std::strin
                                                                 Connection& connection) const
 try
 {
-    const std::string url{SFSUrlComponents::GetDownloadInfoUrl(GetBaseUrl(),
-                                                               m_instanceId,
-                                                               m_nameSpace,
-                                                               product,
-                                                               version,
-                                                               m_reportingHandler)};
+    const std::string url{
+        SFSUrlComponents::GetDownloadInfoUrl(GetBaseUrl(), m_instanceId, m_nameSpace, product, version)};
 
     LOG_INFO(m_reportingHandler,
              "Requesting download info of version [%s] of [%s] from URL [%s]",
@@ -422,8 +412,7 @@ std::string SFSClientImpl<ConnectionManagerT>::GetBaseUrl() const
     {
         return *m_customBaseUrl;
     }
-
-    return "https://" + SFSUrlComponents::UrlEscape(m_accountId + "." + std::string(c_apiDomain), m_reportingHandler);
+    return "https://" + m_accountId + "." + std::string(c_apiDomain);
 }
 
 template class SFS::details::SFSClientImpl<CurlConnectionManager>;

--- a/client/src/details/SFSUrlComponents.cpp
+++ b/client/src/details/SFSUrlComponents.cpp
@@ -3,105 +3,57 @@
 
 #include "SFSUrlComponents.h"
 
-#include "ErrorHandling.h"
-#include "ReportingHandler.h"
-
-#include <curl/curl.h>
-
 using namespace SFS::details;
 
 namespace
 {
-struct CurlEscapedString
-{
-  public:
-    CurlEscapedString(const std::string& str, const ReportingHandler& handler)
-    {
-        m_escapedString = curl_easy_escape(nullptr /*ignored*/, str.c_str(), static_cast<int>(str.length()));
-        THROW_CODE_IF_LOG(Unexpected,
-                          m_escapedString == nullptr,
-                          handler,
-                          "Failed to escape string using curl_easy_escape");
-    }
-
-    ~CurlEscapedString()
-    {
-        curl_free(m_escapedString);
-    }
-
-    CurlEscapedString(const CurlEscapedString&) = delete;
-    CurlEscapedString& operator=(const CurlEscapedString&) = delete;
-
-    char* Get()
-    {
-        return m_escapedString;
-    }
-
-  private:
-    char* m_escapedString = nullptr;
-};
-
 std::string GetNamesUrlComponent(const std::string& baseUrl,
                                  const std::string& instanceId,
-                                 const std::string& nameSpace,
-                                 const ReportingHandler& handler)
+                                 const std::string& nameSpace)
 {
     // Currently using same v2 API for all URLs of the Client
-    return baseUrl + "/api/v2/contents/" + SFSUrlComponents::UrlEscape(instanceId, handler) + "/namespaces/" +
-           SFSUrlComponents::UrlEscape(nameSpace, handler) + "/names";
+    return baseUrl + "/api/v2/contents/" + instanceId + "/namespaces/" + nameSpace + "/names";
 }
 
 std::string GetVersionsUrlComponent(const std::string& baseUrl,
                                     const std::string& instanceId,
                                     const std::string& nameSpace,
-                                    const std::string& product,
-                                    const ReportingHandler& handler)
+                                    const std::string& product)
 {
-    return GetNamesUrlComponent(baseUrl, instanceId, nameSpace, handler) + "/" +
-           SFSUrlComponents::UrlEscape(product, handler) + "/versions/";
+    return GetNamesUrlComponent(baseUrl, instanceId, nameSpace) + "/" + product + "/versions/";
 }
 } // namespace
 
 std::string SFSUrlComponents::GetLatestVersionUrl(const std::string& baseUrl,
                                                   const std::string& instanceId,
                                                   const std::string& nameSpace,
-                                                  const std::string& product,
-                                                  const ReportingHandler& handler)
+                                                  const std::string& product)
 {
-    return GetVersionsUrlComponent(baseUrl, instanceId, nameSpace, product, handler) + "latest?action=select";
+    return GetVersionsUrlComponent(baseUrl, instanceId, nameSpace, product) + "latest?action=select";
 }
 
 std::string SFSUrlComponents::GetLatestVersionBatchUrl(const std::string& baseUrl,
                                                        const std::string& instanceId,
-                                                       const std::string& nameSpace,
-                                                       const ReportingHandler& handler)
+                                                       const std::string& nameSpace)
 {
-    return GetNamesUrlComponent(baseUrl, instanceId, nameSpace, handler) + "?action=BatchUpdates";
+    return GetNamesUrlComponent(baseUrl, instanceId, nameSpace) + "?action=BatchUpdates";
 }
 
 std::string SFSUrlComponents::GetSpecificVersionUrl(const std::string& baseUrl,
                                                     const std::string& instanceId,
                                                     const std::string& nameSpace,
                                                     const std::string& product,
-                                                    const std::string& version,
-                                                    const ReportingHandler& handler)
+                                                    const std::string& version)
 {
-    return GetVersionsUrlComponent(baseUrl, instanceId, nameSpace, product, handler) +
-           SFSUrlComponents::UrlEscape(version, handler);
+    return GetVersionsUrlComponent(baseUrl, instanceId, nameSpace, product) + version;
 }
 
 std::string SFSUrlComponents::GetDownloadInfoUrl(const std::string& baseUrl,
                                                  const std::string& instanceId,
                                                  const std::string& nameSpace,
                                                  const std::string& product,
-                                                 const std::string& version,
-                                                 const ReportingHandler& handler)
+                                                 const std::string& version)
 {
-    return GetVersionsUrlComponent(baseUrl, instanceId, nameSpace, product, handler) +
-           SFSUrlComponents::UrlEscape(version, handler) + "/files?action=GenerateDownloadInfo";
-}
-
-std::string SFSUrlComponents::UrlEscape(const std::string& str, const ReportingHandler& handler)
-{
-    return CurlEscapedString(str, handler).Get();
+    return GetVersionsUrlComponent(baseUrl, instanceId, nameSpace, product) + version +
+           "/files?action=GenerateDownloadInfo";
 }

--- a/client/src/details/SFSUrlComponents.h
+++ b/client/src/details/SFSUrlComponents.h
@@ -7,40 +7,28 @@
 
 namespace SFS::details
 {
-class ReportingHandler;
-
 class SFSUrlComponents
 {
   public:
     static std::string GetLatestVersionUrl(const std::string& baseUrl,
                                            const std::string& instanceId,
                                            const std::string& nameSpace,
-                                           const std::string& product,
-                                           const ReportingHandler& handler);
+                                           const std::string& product);
 
     static std::string GetLatestVersionBatchUrl(const std::string& baseUrl,
                                                 const std::string& instanceId,
-                                                const std::string& nameSpace,
-                                                const ReportingHandler& handler);
+                                                const std::string& nameSpace);
 
     static std::string GetSpecificVersionUrl(const std::string& baseUrl,
                                              const std::string& instanceId,
                                              const std::string& nameSpace,
                                              const std::string& product,
-                                             const std::string& version,
-                                             const ReportingHandler& handler);
+                                             const std::string& version);
 
     static std::string GetDownloadInfoUrl(const std::string& baseUrl,
                                           const std::string& instanceId,
                                           const std::string& nameSpace,
                                           const std::string& product,
-                                          const std::string& version,
-                                          const ReportingHandler& handler);
-
-    /**
-     * @brief Escape the string @param str to be used in a URL
-     * @return The escaped string
-     */
-    static std::string UrlEscape(const std::string& str, const ReportingHandler& handler);
+                                          const std::string& version);
 };
 } // namespace SFS::details

--- a/client/tests/functional/details/CurlConnectionTests.cpp
+++ b/client/tests/functional/details/CurlConnectionTests.cpp
@@ -102,8 +102,7 @@ TEST("Testing CurlConnection()")
                                                                         c_instanceId,
                                                                         c_namespace,
                                                                         c_productName,
-                                                                        c_version,
-                                                                        handler);
+                                                                        c_version);
 
         // Before registering the product, the URL returns 404 Not Found
         REQUIRE_THROWS_CODE(connection->Get(url), HttpNotFound);
@@ -128,7 +127,7 @@ TEST("Testing CurlConnection()")
         SECTION("With GetLatestVersionBatch mock")
         {
             const std::string url =
-                SFSUrlComponents::GetLatestVersionBatchUrl(server.GetBaseUrl(), c_instanceId, c_namespace, handler);
+                SFSUrlComponents::GetLatestVersionBatchUrl(server.GetBaseUrl(), c_instanceId, c_namespace);
 
             // Missing proper body returns HttpBadRequest
             REQUIRE_THROWS_CODE(connection->Post(url), HttpBadRequest);
@@ -165,8 +164,7 @@ TEST("Testing CurlConnection()")
                                                                          c_instanceId,
                                                                          c_namespace,
                                                                          c_productName,
-                                                                         c_version,
-                                                                         handler);
+                                                                         c_version);
 
             // Before registering the product, the URL returns 404 Not Found
             REQUIRE_THROWS_CODE(connection->Post(url), HttpNotFound);
@@ -264,8 +262,7 @@ TEST("Testing CurlConnection works from a second ConnectionManager")
                                                                     c_instanceId,
                                                                     c_namespace,
                                                                     c_productName,
-                                                                    c_version,
-                                                                    handler);
+                                                                    c_version);
 
     // Register the product
     server.RegisterProduct(c_productName, c_version);
@@ -301,8 +298,7 @@ TEST("Testing a url that's too big throws 414")
                                                                                     c_instanceId,
                                                                                     c_namespace,
                                                                                     largeProductName,
-                                                                                    c_version,
-                                                                                    handler)),
+                                                                                    c_version)),
                             HttpUnexpected,
                             "Unexpected HTTP code 414");
 }
@@ -326,8 +322,7 @@ TEST("Testing a response over the limit fails the operation")
 
     // Using GetLatestVersionBatch api since the product name is in the body and not in the url, to avoid a 414 error
     // like on the test above
-    const std::string url =
-        SFSUrlComponents::GetLatestVersionBatchUrl(server.GetBaseUrl(), c_instanceId, c_namespace, handler);
+    const std::string url = SFSUrlComponents::GetLatestVersionBatchUrl(server.GetBaseUrl(), c_instanceId, c_namespace);
 
     // Large one works
     json body = {{{"TargetingAttributes", {}}, {"Product", largeProductName}}};
@@ -356,8 +351,7 @@ TEST("Testing MS-CV is sent to server")
                                                                     c_instanceId,
                                                                     c_namespace,
                                                                     c_productName,
-                                                                    c_version,
-                                                                    handler);
+                                                                    c_version);
 
     server.RegisterProduct(c_productName, c_version);
 
@@ -392,8 +386,7 @@ TEST("Testing retry behavior")
                                                                     c_instanceId,
                                                                     c_namespace,
                                                                     c_productName,
-                                                                    c_version,
-                                                                    handler);
+                                                                    c_version);
 
     SECTION("Test exponential backoff")
     {

--- a/client/tests/unit/details/SFSClientImplTests.cpp
+++ b/client/tests/unit/details/SFSClientImplTests.cpp
@@ -386,29 +386,6 @@ TEST("Testing test override SFS_TEST_OVERRIDE_BASE_URL")
     REQUIRE(sfsClient.GetBaseUrl() == "customUrl");
 }
 
-TEST("Test accountId is properly encoded")
-{
-    auto check = [&](const std::string& accountId, const std::string& expectedEncodedAccountId) {
-        ClientConfig config;
-        config.accountId = accountId;
-        SFSClientImpl<MockConnectionManager> sfsClient(std::move(config));
-        REQUIRE(sfsClient.GetBaseUrl() == "https://" + expectedEncodedAccountId + ".api.cdp.microsoft.com");
-    };
-
-    SECTION("No special characters")
-    {
-        check("testAccountId", "testAccountId");
-    }
-
-    SECTION("Special characters")
-    {
-        check("testAccountId<", "testAccountId%3C");
-        check("testAccountId\\", "testAccountId%5C");
-        check("testAccountId ", "testAccountId%20");
-        check("testAccountId@", "testAccountId%40");
-    }
-}
-
 TEST("Testing passing a logging callback to constructor of SFSClientImpl")
 {
     SFSClientImpl<MockConnectionManager> sfsClient(


### PR DESCRIPTION
Helps #99

~When a caller passes unexpected characters that end up in the request URL, the library fails with unexpected errors.
For example "URL rejected: Malformed input to a URL function" if a line break is passed in the product name.~

~Implementing percent-encoding for product name, config namespace, accountId and instanceId.~

PR has been repurposed to only validate that request strings are not empty.