### PR TITLE
Adding UrlBuilder

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -40,6 +40,7 @@ target_sources(
             src/details/SFSException.cpp
             src/details/SFSUrlComponents.cpp
             src/details/TestOverride.cpp
+            src/details/UrlBuilder.cpp
             src/details/Util.cpp
             src/File.cpp
             src/Logging.cpp

--- a/client/include/sfsclient/Result.h
+++ b/client/include/sfsclient/Result.h
@@ -30,6 +30,7 @@ class Result
         // Connection errors start at 0x8000'1000
         ConnectionSetupFailed = 0x8000'1000,
         ConnectionUnexpectedError = 0x8000'1001,
+        ConnectionUrlSetupFailed = 0x8000'1002,
 
         // Http Errors start at 0x8000'2000
         // Generic Http errors

--- a/client/src/Result.cpp
+++ b/client/src/Result.cpp
@@ -86,6 +86,8 @@ std::string_view SFS::ToString(Result::Code code) noexcept
         return "ConnectionSetupFailed";
     case Result::ConnectionUnexpectedError:
         return "ConnectionUnexpectedError";
+    case Result::ConnectionUrlSetupFailed:
+        return "ConnectionUrlSetupFailed";
 
     // Http Errors
     case Result::HttpTimeout:

--- a/client/src/details/UrlBuilder.cpp
+++ b/client/src/details/UrlBuilder.cpp
@@ -43,6 +43,7 @@ std::string GetCurlUrlStrError(CURLUcode code)
 UrlBuilder::UrlBuilder(const ReportingHandler& handler) : m_handler(handler)
 {
     m_handle = curl_url();
+    THROW_CODE_IF_NOT_LOG(ConnectionUrlSetupFailed, m_handle, m_handler, "Curl URL error: Failed to create URL");
 }
 
 UrlBuilder::~UrlBuilder()

--- a/client/src/details/UrlBuilder.cpp
+++ b/client/src/details/UrlBuilder.cpp
@@ -10,14 +10,14 @@
 
 #include <memory>
 
-#define THROW_IF_CURLU_ERROR(curlCall, error)                                                                          \
+#define THROW_IF_CURL_URL_ERROR(curlCall, error)                                                                       \
     do                                                                                                                 \
     {                                                                                                                  \
         auto __curlUrlCode = (curlCall);                                                                               \
         THROW_CODE_IF_NOT_LOG(error, __curlUrlCode == CURLUE_OK, m_handler, GetCurlUrlStrError(__curlUrlCode));        \
     } while ((void)0, 0)
 
-#define THROW_IF_CURLU_SETUP_ERROR(curlCall) THROW_IF_CURLU_ERROR(curlCall, ConnectionUrlSetupFailed)
+#define THROW_IF_CURL_URL_SETUP_ERROR(curlCall) THROW_IF_CURL_URL_ERROR(curlCall, ConnectionUrlSetupFailed)
 
 using namespace SFS::details;
 
@@ -57,7 +57,7 @@ std::string UrlBuilder::GetUrl() const
 {
     CurlCharPtr url;
     char* urlPtr = url.get();
-    THROW_IF_CURLU_SETUP_ERROR(curl_url_get(m_handle, CURLUPART_URL, &urlPtr, 0 /*flags*/));
+    THROW_IF_CURL_URL_SETUP_ERROR(curl_url_get(m_handle, CURLUPART_URL, &urlPtr, 0 /*flags*/));
     return urlPtr;
 }
 
@@ -66,14 +66,14 @@ void UrlBuilder::SetScheme(Scheme scheme)
     switch (scheme)
     {
     case Scheme::Https:
-        THROW_IF_CURLU_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_SCHEME, "https", 0 /*flags*/));
+        THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_SCHEME, "https", 0 /*flags*/));
         break;
     }
 }
 
 void UrlBuilder::SetHost(const std::string& host)
 {
-    THROW_IF_CURLU_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_HOST, host.c_str(), 0 /*flags*/));
+    THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_HOST, host.c_str(), 0 /*flags*/));
 }
 
 void UrlBuilder::SetPath(const std::string& path, bool encode)
@@ -83,7 +83,7 @@ void UrlBuilder::SetPath(const std::string& path, bool encode)
     {
         flags |= CURLU_URLENCODE;
     }
-    THROW_IF_CURLU_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_PATH, path.c_str(), flags));
+    THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_PATH, path.c_str(), flags));
 }
 
 void UrlBuilder::SetQuery(const std::string& query, bool append)
@@ -93,10 +93,10 @@ void UrlBuilder::SetQuery(const std::string& query, bool append)
     {
         flags |= CURLU_APPENDQUERY;
     }
-    THROW_IF_CURLU_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_QUERY, query.c_str(), flags));
+    THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_QUERY, query.c_str(), flags));
 }
 
 void UrlBuilder::SetUrl(const std::string& url)
 {
-    THROW_IF_CURLU_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_URL, url.c_str(), 0 /*flags*/));
+    THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_URL, url.c_str(), 0 /*flags*/));
 }

--- a/client/src/details/UrlBuilder.cpp
+++ b/client/src/details/UrlBuilder.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "UrlBuilder.h"
+
+#include "ErrorHandling.h"
+#include "ReportingHandler.h"
+
+#include <curl/curl.h>
+
+#define THROW_IF_CURLU_ERROR(curlCall, error)                                                                          \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        auto __curlUrlCode = (curlCall);                                                                               \
+        THROW_CODE_IF_NOT_LOG(error, __curlUrlCode == CURLUE_OK, m_handler, GetCurlUrlStrError(__curlUrlCode));        \
+    } while ((void)0, 0)
+
+#define THROW_IF_CURLU_SETUP_ERROR(curlCall) THROW_IF_CURLU_ERROR(curlCall, ConnectionUrlSetupFailed)
+
+using namespace SFS::details;
+
+namespace
+{
+struct CurlString
+{
+  public:
+    CurlString() = default;
+
+    ~CurlString()
+    {
+        Release();
+    }
+
+    CurlString(const CurlString&) = delete;
+    CurlString& operator=(const CurlString&) = delete;
+
+    char* Get() const
+    {
+        return m_data;
+    }
+
+    char** ReleaseAndGetAddressOf()
+    {
+        Release();
+        return &m_data;
+    }
+
+  private:
+    void Release()
+    {
+        if (m_data)
+        {
+            curl_free(m_data);
+        }
+    }
+
+    char* m_data = nullptr;
+};
+
+std::string GetCurlUrlStrError(CURLUcode code)
+{
+    return "Curl URL error: " + std::string(curl_url_strerror(code));
+}
+} // namespace
+
+UrlBuilder::UrlBuilder(const ReportingHandler& handler) : m_handler(handler)
+{
+    m_handle = curl_url();
+}
+
+UrlBuilder::~UrlBuilder()
+{
+    curl_url_cleanup(m_handle);
+}
+
+std::string UrlBuilder::GetUrl() const
+{
+    CurlString url;
+    THROW_IF_CURLU_SETUP_ERROR(curl_url_get(m_handle, CURLUPART_URL, url.ReleaseAndGetAddressOf(), 0 /*flags*/));
+    return url.Get();
+}
+
+void UrlBuilder::SetScheme(Scheme scheme)
+{
+    switch (scheme)
+    {
+    case Scheme::Https:
+        THROW_IF_CURLU_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_SCHEME, "https", 0 /*flags*/));
+        break;
+    }
+}
+
+void UrlBuilder::SetHost(const std::string& host)
+{
+    THROW_IF_CURLU_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_HOST, host.c_str(), 0 /*flags*/));
+}
+
+void UrlBuilder::SetPath(const std::string& path, bool encode)
+{
+    unsigned flags = 0;
+    if (encode)
+    {
+        flags |= CURLU_URLENCODE;
+    }
+    THROW_IF_CURLU_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_PATH, path.c_str(), flags));
+}
+
+void UrlBuilder::SetQuery(const std::string& query, bool append)
+{
+    unsigned flags = 0;
+    if (append)
+    {
+        flags |= CURLU_APPENDQUERY;
+    }
+    THROW_IF_CURLU_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_QUERY, query.c_str(), flags));
+}
+
+void UrlBuilder::SetUrl(const std::string& url)
+{
+    THROW_IF_CURLU_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_URL, url.c_str(), 0 /*flags*/));
+}

--- a/client/src/details/UrlBuilder.cpp
+++ b/client/src/details/UrlBuilder.cpp
@@ -8,6 +8,8 @@
 
 #include <curl/curl.h>
 
+#include <memory>
+
 #define THROW_IF_CURLU_ERROR(curlCall, error)                                                                          \
     do                                                                                                                 \
     {                                                                                                                  \

--- a/client/src/details/UrlBuilder.cpp
+++ b/client/src/details/UrlBuilder.cpp
@@ -48,6 +48,11 @@ UrlBuilder::UrlBuilder(const ReportingHandler& handler) : m_handler(handler)
     THROW_CODE_IF_NOT_LOG(ConnectionUrlSetupFailed, m_handle, m_handler, "Curl URL error: Failed to create URL");
 }
 
+UrlBuilder::UrlBuilder(const std::string& url, const ReportingHandler& handler) : UrlBuilder(handler)
+{
+    SetUrl(url);
+}
+
 UrlBuilder::~UrlBuilder()
 {
     curl_url_cleanup(m_handle);

--- a/client/src/details/UrlBuilder.cpp
+++ b/client/src/details/UrlBuilder.cpp
@@ -86,14 +86,14 @@ void UrlBuilder::SetPath(const std::string& path, bool encode)
     THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_PATH, path.c_str(), flags));
 }
 
-void UrlBuilder::SetQuery(const std::string& query, bool append)
+void UrlBuilder::SetQuery(const std::string& query)
 {
-    unsigned flags = 0;
-    if (append)
-    {
-        flags |= CURLU_APPENDQUERY;
-    }
-    THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_QUERY, query.c_str(), flags));
+    THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_QUERY, query.c_str(), 0 /*flags*/));
+}
+
+void UrlBuilder::AppendQuery(const std::string& query)
+{
+    THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_QUERY, query.c_str(), CURLU_APPENDQUERY));
 }
 
 void UrlBuilder::SetUrl(const std::string& url)

--- a/client/src/details/UrlBuilder.h
+++ b/client/src/details/UrlBuilder.h
@@ -53,10 +53,16 @@ class UrlBuilder
     /**
      * @brief Set a query to the URL
      * @param query The query to set to the URL. Ex: key=value
-     * @param append If true, the query will be appended to the existing query
      * @throws SFSException if the string is invalid
      */
-    void SetQuery(const std::string& query, bool append = false);
+    void SetQuery(const std::string& query);
+
+    /**
+     * @brief Append a query to the URL
+     * @param query The query to append to the URL. Ex: key=value
+     * @throws SFSException if the string is invalid
+     */
+    void AppendQuery(const std::string& query);
 
     /**
      * @brief Set the URL through a string. Other methods can still be called later to modify the URl

--- a/client/src/details/UrlBuilder.h
+++ b/client/src/details/UrlBuilder.h
@@ -21,7 +21,17 @@ enum class Scheme
 class UrlBuilder
 {
   public:
-    UrlBuilder(const ReportingHandler& handler);
+    /**
+     * @brief Construct a new Url Builder object with an empty URL
+     */
+    explicit UrlBuilder(const ReportingHandler& handler);
+
+    /**
+     * @brief Construct a new Url Builder object with an existing URL
+     * @param url The URL to set
+     */
+    UrlBuilder(const std::string& url, const ReportingHandler& handler);
+
     ~UrlBuilder();
 
     UrlBuilder(const UrlBuilder&) = delete;

--- a/client/src/details/UrlBuilder.h
+++ b/client/src/details/UrlBuilder.h
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+
+// Forward declaration
+struct Curl_URL;
+typedef struct Curl_URL CURLU;
+
+namespace SFS::details
+{
+class ReportingHandler;
+
+enum class Scheme
+{
+    Https,
+};
+
+class UrlBuilder
+{
+  public:
+    UrlBuilder(const ReportingHandler& handler);
+    ~UrlBuilder();
+
+    UrlBuilder(const UrlBuilder&) = delete;
+    UrlBuilder& operator=(const UrlBuilder&) = delete;
+
+    std::string GetUrl() const;
+
+    /**
+     * @brief Set the scheme for the URL
+     * @param scheme The scheme to set for the URL Ex: Https
+     */
+    void SetScheme(Scheme scheme);
+
+    /**
+     * @brief Set the host for the URL
+     * @param host The host to set for the URL. Ex: www.example.com
+     * @throws SFSException if the string is invalid
+     */
+    void SetHost(const std::string& host);
+
+    /**
+     * @brief Set a path to the URL
+     * @param path The path to set for the URL. Ex: index.html
+     * @param encode If true, the path will be URL encoded
+     * @throws SFSException if the string is invalid
+     */
+    void SetPath(const std::string& path, bool encode = false);
+
+    /**
+     * @brief Set a query to the URL
+     * @param query The query to set to the URL. Ex: key=value
+     * @param append If true, the query will be appended to the existing query
+     * @throws SFSException if the string is invalid
+     */
+    void SetQuery(const std::string& query, bool append = false);
+
+    /**
+     * @brief Set the URL through a string. Other methods can still be called later to modify the URl
+     * @param url The string to set as URL. Ex: http://www.example.com/index.html
+     * @throws SFSException if the string is invalid
+     */
+    void SetUrl(const std::string& url);
+
+  private:
+    const ReportingHandler& m_handler;
+
+    CURLU* m_handle = nullptr;
+};
+} // namespace SFS::details

--- a/client/tests/CMakeLists.txt
+++ b/client/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(
             unit/details/ReportingHandlerTests.cpp
             unit/details/SFSClientImplTests.cpp
             unit/details/TestOverrideTests.cpp
+            unit/details/UrlBuilderTests.cpp
             unit/details/UtilTests.cpp
             unit/FileTests.cpp
             unit/ResultTests.cpp

--- a/client/tests/unit/details/UrlBuilderTests.cpp
+++ b/client/tests/unit/details/UrlBuilderTests.cpp
@@ -54,15 +54,15 @@ TEST("UrlBuilder")
         REQUIRE(builder.GetUrl() == "https://www.example.com/index%3e%40/index");
     }
 
-    SECTION("SetQuery")
+    SECTION("SetQuery, AppendQuery")
     {
         builder.SetQuery("key=value");
         REQUIRE(builder.GetUrl() == "https://www.example.com/?key=value");
 
-        builder.SetQuery("key2=value2", true /*append*/);
+        builder.AppendQuery("key2=value2");
         REQUIRE(builder.GetUrl() == "https://www.example.com/?key=value&key2=value2");
 
-        builder.SetQuery("key2=value2", false /*append*/);
+        builder.SetQuery("key2=value2");
         REQUIRE(builder.GetUrl() == "https://www.example.com/?key2=value2");
     }
 
@@ -75,7 +75,7 @@ TEST("UrlBuilder")
                                 "Curl URL error: Bad hostname");
     }
 
-    SECTION("SetScheme, SetHost, SetPath, AppendQuery")
+    SECTION("SetScheme, SetHost, SetPath, SetQuery")
     {
         builder.SetScheme(Scheme::Https);
         builder.SetHost("www.example.com");
@@ -85,7 +85,7 @@ TEST("UrlBuilder")
         REQUIRE(builder.GetUrl() == "https://www.example.com/index.html?key=value");
     }
 
-    SECTION("SetScheme, SetHost, SetPath, AppendQuery with encoding")
+    SECTION("SetScheme, SetHost, SetPath, SetQuery with encoding")
     {
         builder.SetScheme(Scheme::Https);
         builder.SetHost("www.example.com");

--- a/client/tests/unit/details/UrlBuilderTests.cpp
+++ b/client/tests/unit/details/UrlBuilderTests.cpp
@@ -94,4 +94,14 @@ TEST("UrlBuilder")
 
         REQUIRE(builder.GetUrl() == "https://www.example.com/index%40.html?key=value");
     }
+
+    SECTION("Constructor with URL")
+    {
+        UrlBuilder builder2("https://www.example.com/index.html?key=value", handler);
+        REQUIRE(builder2.GetUrl() == "https://www.example.com/index.html?key=value");
+
+        REQUIRE_THROWS_CODE_MSG(UrlBuilder("https://www.+.com", handler),
+                                ConnectionUrlSetupFailed,
+                                "Curl URL error: Bad hostname");
+    }
 }

--- a/client/tests/unit/details/UrlBuilderTests.cpp
+++ b/client/tests/unit/details/UrlBuilderTests.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "../../util/SFSExceptionMatcher.h"
+#include "../../util/TestHelper.h"
+#include "ReportingHandler.h"
+#include "UrlBuilder.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#define TEST(...) TEST_CASE("[UrlBuilderTests] " __VA_ARGS__)
+
+using namespace SFS::details;
+using namespace SFS::test;
+
+TEST("UrlBuilder")
+{
+    ReportingHandler handler;
+    handler.SetLoggingCallback(LogCallbackToTest);
+
+    UrlBuilder builder(handler);
+    REQUIRE_THROWS_CODE_MSG(builder.GetUrl(), ConnectionUrlSetupFailed, "Curl URL error: No host part in the URL");
+
+    builder.SetHost("www.example.com");
+    REQUIRE_THROWS_CODE_MSG(builder.GetUrl(), ConnectionUrlSetupFailed, "Curl URL error: No scheme part in the URL");
+
+    builder.SetScheme(Scheme::Https);
+    REQUIRE(builder.GetUrl() == "https://www.example.com/");
+
+    SECTION("SetHost")
+    {
+        builder.SetHost("www.example2.com");
+        REQUIRE(builder.GetUrl() == "https://www.example2.com/");
+
+        REQUIRE_THROWS_CODE_MSG(builder.SetHost("+"), ConnectionUrlSetupFailed, "Curl URL error: Bad hostname");
+        REQUIRE_THROWS_CODE_MSG(builder.SetHost("a&b"), ConnectionUrlSetupFailed, "Curl URL error: Bad hostname");
+        REQUIRE_THROWS_CODE_MSG(builder.SetHost("a\nb"), ConnectionUrlSetupFailed, "Curl URL error: Bad hostname");
+        REQUIRE_THROWS_CODE_MSG(builder.SetHost("a\tb"), ConnectionUrlSetupFailed, "Curl URL error: Bad hostname");
+    }
+
+    SECTION("SetPath")
+    {
+        builder.SetPath("index.html");
+        REQUIRE(builder.GetUrl() == "https://www.example.com/index.html");
+
+        builder.SetPath("index.html", true);
+        REQUIRE(builder.GetUrl() == "https://www.example.com/index.html");
+
+        builder.SetPath("index>@", true);
+        REQUIRE(builder.GetUrl() == "https://www.example.com/index%3e%40");
+
+        INFO("Encoding skips the / character");
+        builder.SetPath("index>@/index", true);
+        REQUIRE(builder.GetUrl() == "https://www.example.com/index%3e%40/index");
+    }
+
+    SECTION("SetQuery")
+    {
+        builder.SetQuery("key=value");
+        REQUIRE(builder.GetUrl() == "https://www.example.com/?key=value");
+
+        builder.SetQuery("key2=value2", true /*append*/);
+        REQUIRE(builder.GetUrl() == "https://www.example.com/?key=value&key2=value2");
+
+        builder.SetQuery("key2=value2", false /*append*/);
+        REQUIRE(builder.GetUrl() == "https://www.example.com/?key2=value2");
+    }
+
+    SECTION("SetUrl")
+    {
+        builder.SetUrl("https://www.example.com/index.html?key=value");
+        REQUIRE(builder.GetUrl() == "https://www.example.com/index.html?key=value");
+        REQUIRE_THROWS_CODE_MSG(builder.SetUrl("https://www.+.com"),
+                                ConnectionUrlSetupFailed,
+                                "Curl URL error: Bad hostname");
+    }
+
+    SECTION("SetScheme, SetHost, SetPath, AppendQuery")
+    {
+        builder.SetScheme(Scheme::Https);
+        builder.SetHost("www.example.com");
+        builder.SetPath("index.html");
+        builder.SetQuery("key=value");
+
+        REQUIRE(builder.GetUrl() == "https://www.example.com/index.html?key=value");
+    }
+
+    SECTION("SetScheme, SetHost, SetPath, AppendQuery with encoding")
+    {
+        builder.SetScheme(Scheme::Https);
+        builder.SetHost("www.example.com");
+        builder.SetPath("index@.html", true);
+        builder.SetQuery("key=value");
+
+        REQUIRE(builder.GetUrl() == "https://www.example.com/index%40.html?key=value");
+    }
+}


### PR DESCRIPTION
Closes #33, helps #99.

Wraps around the [libcurl-ur](https://curl.se/libcurl/c/libcurl-url.html) interface from curl. Enables one to create a valid URL through building blocks, setting different URL parts.
Exposes only the things we make use of in SFSClient.

Will be used in SFSClient in #99.