### PR TITLE
UrlBuilder Set/AppendQuery to encode params

### DIFF
--- a/client/src/details/UrlBuilder.cpp
+++ b/client/src/details/UrlBuilder.cpp
@@ -112,7 +112,7 @@ UrlBuilder& UrlBuilder::AppendPath(const std::string& path, bool encode)
 
     if (encode)
     {
-        m_path += EscapeString(path);
+        m_path += URLEncode(path);
     }
     else
     {
@@ -133,7 +133,7 @@ UrlBuilder& UrlBuilder::ResetPath()
 UrlBuilder& UrlBuilder::SetQuery(const std::string& key, const std::string& value)
 {
     THROW_CODE_IF_LOG(InvalidArg, key.empty() || value.empty(), m_handler, "Query key and value must not empty");
-    const std::string query = EscapeString(key) + "=" + EscapeString(value);
+    const std::string query = URLEncode(key) + "=" + URLEncode(value);
     THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_QUERY, query.c_str(), 0 /*flags*/));
     return *this;
 }
@@ -141,7 +141,7 @@ UrlBuilder& UrlBuilder::SetQuery(const std::string& key, const std::string& valu
 UrlBuilder& UrlBuilder::AppendQuery(const std::string& key, const std::string& value)
 {
     THROW_CODE_IF_LOG(InvalidArg, key.empty() || value.empty(), m_handler, "Query key and value must not empty");
-    const std::string query = EscapeString(key) + "=" + EscapeString(value);
+    const std::string query = URLEncode(key) + "=" + URLEncode(value);
     THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_QUERY, query.c_str(), CURLU_APPENDQUERY));
     return *this;
 }
@@ -159,9 +159,9 @@ UrlBuilder& UrlBuilder::SetUrl(const std::string& url)
     return *this;
 }
 
-std::string UrlBuilder::EscapeString(const std::string& str) const
+std::string UrlBuilder::URLEncode(const std::string& str) const
 {
-    CurlCharPtr escapedStr{curl_easy_escape(nullptr /*ignored*/, str.c_str(), static_cast<int>(str.length()))};
-    THROW_CODE_IF_NOT_LOG(ConnectionUrlSetupFailed, escapedStr, m_handler, "Failed to escape URL string");
-    return escapedStr.get();
+    CurlCharPtr encodedStr{curl_easy_escape(nullptr /*ignored*/, str.c_str(), static_cast<int>(str.length()))};
+    THROW_CODE_IF_NOT_LOG(ConnectionUrlSetupFailed, encodedStr, m_handler, "Failed to URL-encode string");
+    return encodedStr.get();
 }

--- a/client/src/details/UrlBuilder.cpp
+++ b/client/src/details/UrlBuilder.cpp
@@ -133,7 +133,7 @@ UrlBuilder& UrlBuilder::ResetPath()
 UrlBuilder& UrlBuilder::SetQuery(const std::string& key, const std::string& value)
 {
     THROW_CODE_IF_LOG(InvalidArg, key.empty() || value.empty(), m_handler, "Query key and value must not empty");
-    const std::string query = key + "=" + value;
+    const std::string query = EscapeString(key) + "=" + EscapeString(value);
     THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_QUERY, query.c_str(), 0 /*flags*/));
     return *this;
 }
@@ -141,7 +141,7 @@ UrlBuilder& UrlBuilder::SetQuery(const std::string& key, const std::string& valu
 UrlBuilder& UrlBuilder::AppendQuery(const std::string& key, const std::string& value)
 {
     THROW_CODE_IF_LOG(InvalidArg, key.empty() || value.empty(), m_handler, "Query key and value must not empty");
-    const std::string query = key + "=" + value;
+    const std::string query = EscapeString(key) + "=" + EscapeString(value);
     THROW_IF_CURL_URL_SETUP_ERROR(curl_url_set(m_handle, CURLUPART_QUERY, query.c_str(), CURLU_APPENDQUERY));
     return *this;
 }

--- a/client/src/details/UrlBuilder.h
+++ b/client/src/details/UrlBuilder.h
@@ -88,6 +88,7 @@ class UrlBuilder
      * @brief Set a query to the URL (?key=value)
      * @param key The key of the query string. Ex: value
      * @param value The value of the query string. Ex: value
+     * @note Both key and value will be URL encoded
      * @throws SFSException if the string is invalid
      * @return The reference to the current object
      */
@@ -97,6 +98,7 @@ class UrlBuilder
      * @brief Append a query to the URL (&key=value)
      * @param key The key of the query string. Ex: value
      * @param value The value of the query string. Ex: value
+     * @note Both key and value will be URL encoded
      * @throws SFSException if the string is invalid
      * @return The reference to the current object
      */

--- a/client/src/details/UrlBuilder.h
+++ b/client/src/details/UrlBuilder.h
@@ -129,9 +129,9 @@ class UrlBuilder
     UrlBuilder& AppendPath(const std::string& path, bool encode);
 
     /**
-     * @brief URL-escape a given string
+     * @brief URL-encode (or percent-encode) a given string
      */
-    std::string EscapeString(const std::string& str) const;
+    std::string URLEncode(const std::string& str) const;
 
     const ReportingHandler& m_handler;
 

--- a/client/tests/unit/details/UrlBuilderTests.cpp
+++ b/client/tests/unit/details/UrlBuilderTests.cpp
@@ -87,6 +87,12 @@ TEST("UrlBuilder")
         builder.SetQuery("key2", "value2");
         REQUIRE(builder.GetUrl() == "https://www.example.com/?key2=value2");
 
+        builder.AppendQuery("key3", "valu/e@2");
+        REQUIRE(builder.GetUrl() == "https://www.example.com/?key2=value2&key3=valu%2fe%402");
+
+        builder.SetQuery("ke$y4", "valu/e@3");
+        REQUIRE(builder.GetUrl() == "https://www.example.com/?ke%24y4=valu%2fe%403");
+
         REQUIRE_THROWS_CODE_MSG(builder.SetQuery("", "value"), InvalidArg, "Query key and value must not empty");
         REQUIRE_THROWS_CODE_MSG(builder.SetQuery("key", ""), InvalidArg, "Query key and value must not empty");
         REQUIRE_THROWS_CODE_MSG(builder.SetQuery("", ""), InvalidArg, "Query key and value must not empty");


### PR DESCRIPTION
Helps #99

UrlBuilder Set/AppendQuery to encode params

We can't use CURLU_URLENCODE on SetQuery as it'll encode the '='. And I'd rather not use two different encoding functions in SetQuery and AppendQuery. So using EscapeString() instead on both.