### PR TITLE
Expanding clang-format to all cpp

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -18,7 +18,7 @@
 #   .*: Matches any number of characters (. means any character except newline, and * means match any number of the character before, including 0)
 #   (\.cpp|\.h): Match either .cpp or .h. The . character is escaped because it has a special meaning in regex.
 #   $: Match end of string
-pattern_to_include_in_clang_format='^client/.*(\.cpp|\.h)$'
+pattern_to_include_in_clang_format='(\.cpp|\.h)$'
 pattern_to_include_in_cmake_format='CMakeLists.txt'
 
 # Get the names of staged files (--cached) that are not deleted (--diff-filter=d)

--- a/samples/integration-do-client/IntegrationDOClient.cpp
+++ b/samples/integration-do-client/IntegrationDOClient.cpp
@@ -171,8 +171,7 @@ std::string TimestampToString(std::chrono::time_point<std::chrono::system_clock>
 void LoggingCallback(const SFS::LogData& logData)
 {
     std::cout << c_darkGreyStart << "Log: " << TimestampToString(logData.time) << " [" << ToString(logData.severity)
-              << "]"
-              << " " << std::filesystem::path(logData.file).filename().string() << ":" << logData.line << " "
+              << "]" << " " << std::filesystem::path(logData.file).filename().string() << ":" << logData.line << " "
               << logData.message << c_colorEnd << std::endl;
 }
 

--- a/samples/tool/SFSClientTool.cpp
+++ b/samples/tool/SFSClientTool.cpp
@@ -348,8 +348,7 @@ std::string TimestampToString(std::chrono::time_point<std::chrono::system_clock>
 void LoggingCallback(const SFS::LogData& logData)
 {
     std::cout << c_darkGreyStart << "Log: " << TimestampToString(logData.time) << " [" << ToString(logData.severity)
-              << "]"
-              << " " << std::filesystem::path(logData.file).filename().string() << ":" << logData.line << " "
+              << "]" << " " << std::filesystem::path(logData.file).filename().string() << ":" << logData.line << " "
               << logData.message << c_colorEnd << std::endl;
 }
 


### PR DESCRIPTION
Helps #169 
Now we also run clang-format in the pre-commit script on changes made to the samples folder, and new folders that may come.
The script only runs on tracked git files, so there is no risk of running on non-committed files.