### PR TITLE
User-Agent: Suggestions

### DIFF
--- a/client/src/details/OSInfo.cpp
+++ b/client/src/details/OSInfo.cpp
@@ -7,18 +7,13 @@
 
 #include <windows.h>
 
-#include <VersionHelpers.h>
 #include <sysinfoapi.h>
 
 #elif __GNUG__
 
-#include <filesystem>
-#include <fstream>
 #include <sys/utsname.h>
 
 #endif
-
-#include <sstream>
 
 using namespace SFS::details;
 
@@ -27,10 +22,7 @@ namespace
 #ifdef _WIN32
 std::string GetWindowsOSVersion()
 {
-    // In Windows, the API below only works if the application has a manifest file with indications to the supported OS
-    // version (https://learn.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-application-at-windows-8-1).
-    // If the caller application does not have a manifest file, this function will just return "Windows"
-    return IsWindows10OrGreater() ? "Windows NT 10.0" : "Windows";
+    return "Windows";
 }
 
 std::string GetWindowsMachineInfo()
@@ -57,24 +49,7 @@ std::string GetWindowsMachineInfo()
 #ifdef __GNUG__
 std::string GetLinuxOSVersion()
 {
-    // Check for /etc/os-release file, which contains information about the distribution
-    static const std::string s_osReleaseFile = "/etc/os-release";
-    if (std::filesystem::exists(s_osReleaseFile))
-    {
-        std::ifstream file(s_osReleaseFile);
-        std::string line;
-        while (std::getline(file, line))
-        {
-            // The PRETTY_NAME line contains the name of the distribution like PRETTY_NAME="Ubuntu 22.04.3 LTS"
-            if (line.find("PRETTY_NAME") != std::string::npos)
-            {
-                // Extract the name of the distribution by removing the quotes
-                return line.substr(line.find("\"") + 1, line.rfind("\"") - line.find("\"") - 1);
-            }
-        }
-    }
-
-    // Linux distro not found, return kernel name
+    // Return kernel name, usually "Linux"
     utsname buf;
     if (uname(&buf) >= 0)
     {

--- a/client/src/details/OSInfo.cpp
+++ b/client/src/details/OSInfo.cpp
@@ -69,17 +69,7 @@ std::string GetOSMachineInfo()
 }
 
 #else
-
-std::string GetPlatform()
-{
-    return "Unknown";
-}
-
-std::string GetOSMachineInfo()
-{
-    return "Unknown Machine";
-}
-
+#error "Unsupported platform"
 #endif
 } // namespace
 

--- a/client/src/details/OSInfo.cpp
+++ b/client/src/details/OSInfo.cpp
@@ -9,7 +9,7 @@
 
 #include <sysinfoapi.h>
 
-#elif __GNUG__
+#elif __linux__
 
 #include <sys/utsname.h>
 
@@ -20,12 +20,12 @@ using namespace SFS::details;
 namespace
 {
 #ifdef _WIN32
-std::string GetWindowsOSVersion()
+std::string GetPlatform()
 {
     return "Windows";
 }
 
-std::string GetWindowsMachineInfo()
+std::string GetOSMachineInfo()
 {
     SYSTEM_INFO systemInfo;
     GetNativeSystemInfo(&systemInfo);
@@ -44,10 +44,10 @@ std::string GetWindowsMachineInfo()
         return "Unknown";
     }
 }
-#endif
 
-#ifdef __GNUG__
-std::string GetLinuxOSVersion()
+#elif __linux__
+
+std::string GetPlatform()
 {
     // Return kernel name, usually "Linux"
     utsname buf;
@@ -58,7 +58,7 @@ std::string GetLinuxOSVersion()
     return "Unknown";
 }
 
-std::string GetLinuxMachineInfo()
+std::string GetOSMachineInfo()
 {
     utsname buf;
     if (uname(&buf) >= 0)
@@ -67,27 +67,28 @@ std::string GetLinuxMachineInfo()
     }
     return "Unknown";
 }
+
+#else
+
+std::string GetPlatform()
+{
+    return "Unknown";
+}
+
+std::string GetOSMachineInfo()
+{
+    return "Unknown Machine";
+}
+
 #endif
 } // namespace
 
-std::string osinfo::GetOSVersion()
+std::string osinfo::GetPlatform()
 {
-#ifdef _WIN32
-    return GetWindowsOSVersion();
-#elif __GNUG__
-    return GetLinuxOSVersion();
-#else
-    return "Unknown OS";
-#endif
+    return ::GetPlatform();
 }
 
 std::string osinfo::GetOSMachineInfo()
 {
-#ifdef _WIN32
-    return GetWindowsMachineInfo();
-#elif __GNUG__
-    return GetLinuxMachineInfo();
-#else
-    return "Unknown Machine";
-#endif
+    return ::GetOSMachineInfo();
 }

--- a/client/src/details/OSInfo.h
+++ b/client/src/details/OSInfo.h
@@ -7,6 +7,6 @@
 
 namespace SFS::details::osinfo
 {
-std::string GetOSVersion();
+std::string GetPlatform();
 std::string GetOSMachineInfo();
 } // namespace SFS::details::osinfo

--- a/client/src/details/connection/HttpHeader.cpp
+++ b/client/src/details/connection/HttpHeader.cpp
@@ -34,5 +34,5 @@ std::string SFS::details::GetUserAgentValue()
     // - Microsoft-SFSClient/1.0.0 (Windows; x64)
     // - Microsoft-SFSClient/1.0.0 (Linux; x86_64)
 
-    return c_userAgent + " ("s + osinfo::GetOSVersion() + "; "s + osinfo::GetOSMachineInfo() + ")"s;
+    return c_userAgent + " ("s + osinfo::GetPlatform() + "; "s + osinfo::GetOSMachineInfo() + ")"s;
 }

--- a/client/src/details/connection/HttpHeader.cpp
+++ b/client/src/details/connection/HttpHeader.cpp
@@ -31,8 +31,8 @@ std::string SFS::details::ToString(HttpHeader header)
 std::string SFS::details::GetUserAgentValue()
 {
     // Examples:
-    // - Microsoft-SFSClient/1.0.0 (Windows NT 10.0; x64)
-    // - Microsoft-SFSClient/1.0.0 (Ubuntu 22.04.3 LTS; x86_64)
+    // - Microsoft-SFSClient/1.0.0 (Windows; x64)
+    // - Microsoft-SFSClient/1.0.0 (Linux; x86_64)
 
     return c_userAgent + " ("s + osinfo::GetOSVersion() + "; "s + osinfo::GetOSMachineInfo() + ")"s;
 }


### PR DESCRIPTION
#### Related Issues

- Closes #186

#### Why is this change being made?

Suggestions made offline on the User-Agent flow.

#### What is being changed?

- No longer sending OS version. Strings are restricted to "Windows" and "Linux"
- Simplifying ifdef flow
- Using `__linux__` macro

#### How was the change tested?

- Current tests test this behavior:  CurlConnectionTests
