### PR TITLE
Install: fixing issues with vcpkg port

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -53,7 +53,7 @@ target_sources(
 target_include_directories(
     ${PROJECT_NAME}
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/sfsclient>
-           $<INSTALL_INTERFACE:include/sfsclient> # <prefix>/include/sfsclient
+           $<INSTALL_INTERFACE:include> # <prefix>/include
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE CURL::libcurl)

--- a/sfs-client-vcpkg-port/sfs-client/usage
+++ b/sfs-client-vcpkg-port/sfs-client/usage
@@ -1,4 +1,4 @@
 The package sfs-client provides CMake targets:
 
-    find_package(sfs-client CONFIG REQUIRED)
+    find_package(sfsclient CONFIG REQUIRED)
     target_link_libraries(main PRIVATE microsoft::sfsclient)


### PR DESCRIPTION
#### Related Issues

- Helps #134

#### Why is this change being made?

Small issues identified while using the porfile from an external location.

#### What is being changed?

- Removing the "sfsclient" suffix from the external include dir so people can include our files using `#include <sfsclient/...>`
- Updating the `usage` file as the package folder does not have the hyphen.

#### How was the change tested?

- Builds correctly in external location.
