### PR TITLE
Bumping version to 1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 # 1. MAJOR version when you make incompatible API changes
 # 2. MINOR version when you add functionality in a backward compatible manner
 # 3. PATCH version when you make backward compatible bug fixes
-set(SFS_LIBRARY_VERSION "0.1.0")
+set(SFS_LIBRARY_VERSION "1.0.0")
 
 project(
     sfsclient


### PR DESCRIPTION
#### Related Issues

- Closes #194

#### Why is this change being made?

Bumping version for first release.

#### What is being changed?

Bumping version to 1.0.0.

#### How was the change tested?

 - Not a functional change. Ex: modifying documentation, auxiliary files, etc
