### PR TITLE
User/xiangweiniu/fix missing tab

### DIFF
--- a/samples/tool/SFSClientTool.cpp
+++ b/samples/tool/SFSClientTool.cpp
@@ -30,7 +30,7 @@ void DisplayUsage()
         << "Options:" << std::endl
         << "  -h, --help\t\t\tDisplay this help message" << std::endl
         << "  -v, --version\t\t\tDisplay the library version" << std::endl
-        << "  --isApp\t\tIndicates the specific product is an App" << std::endl
+        << "  --isApp\t\t\tSIndicates the specific product is an App" << std::endl
         << "  --instanceId <id>\t\tA custom SFS instance ID" << std::endl
         << "  --namespace <ns>\t\tA custom SFS namespace" << std::endl
         << "  --customUrl <url>\t\tA custom URL for the SFS service. Library must have been built with SFS_ENABLE_OVERRIDES"

--- a/samples/tool/SFSClientTool.cpp
+++ b/samples/tool/SFSClientTool.cpp
@@ -30,7 +30,7 @@ void DisplayUsage()
         << "Options:" << std::endl
         << "  -h, --help\t\t\tDisplay this help message" << std::endl
         << "  -v, --version\t\t\tDisplay the library version" << std::endl
-        << "  --isApp\t\t\tSIndicates the specific product is an App" << std::endl
+        << "  --isApp\t\t\tIndicates the specific product is an App" << std::endl
         << "  --instanceId <id>\t\tA custom SFS instance ID" << std::endl
         << "  --namespace <ns>\t\tA custom SFS namespace" << std::endl
         << "  --customUrl <url>\t\tA custom URL for the SFS service. Library must have been built with SFS_ENABLE_OVERRIDES"


### PR DESCRIPTION
#### Related Issues

- Helps #193 

#### Why is this change being made?
The "isApp" switch in SFSClientTool help display has a missing tab. The change is to align it to other switches.

#### What is being changed?
Add one more '\t' in DisplayUsage() of SFSClientTool.

#### How was the change tested?
After build, run the following script to verify that the isApp switch align to other switches.
![image](https://github.com/microsoft/sfs-client/assets/92482140/3941656c-8bdf-4046-949e-cd22957bbd5e)

<!-- Uncomment the relevant line below -->
<!-- - Current tests test this behavior: <testnames> -->
<!-- - New tests are being added: <testnames> -->
<!-- - Not a functional change. Ex: modifying documentation, auxiliary files, etc -->
