### PR TITLE
Dependabot: ignoring patch updates for pip dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Ignore patch updates for all pip dependencies
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
#### Related Issues

- Closes #199

#### Why is this change being made?

Our pip dependencies are just formatting tools, we don't need to pick up every patch release. Minor releases should be enough.

#### What is being changed?

Ignoring patch updates for pip dependencies.

#### How was the change tested?

- Not a functional change. Ex: modifying documentation, auxiliary files, etc