### PR TITLE
Forcing faster timeout on timeout test

### DIFF
--- a/client/tests/functional/details/CurlConnectionTests.cpp
+++ b/client/tests/functional/details/CurlConnectionTests.cpp
@@ -45,15 +45,15 @@ class CurlConnectionTimeout : public CurlConnection
 
     std::string Get(const std::string& url) override
     {
-        // Timeout within 100ms
-        curl_easy_setopt(m_handle, CURLOPT_TIMEOUT_MS, 100L);
+        // Timeout within 1ms
+        curl_easy_setopt(m_handle, CURLOPT_TIMEOUT_MS, 1L);
         return CurlConnection::Get(url);
     }
 
     std::string Post(const std::string& url, const std::string& data) override
     {
-        // Timeout within 100ms
-        curl_easy_setopt(m_handle, CURLOPT_TIMEOUT_MS, 100L);
+        // Timeout within 1ms
+        curl_easy_setopt(m_handle, CURLOPT_TIMEOUT_MS, 1L);
         return CurlConnection::Post(url, data);
     }
 };


### PR DESCRIPTION
#### Related Issues

- Closes #201

#### Why is this change being made?

The test "Testing CurlConnection when the server is not reachable" has been having some issues in the internal Azure Pipeline as it seems network is faster there.
Test uses a 10ms timeout, but we can switch to a 1ms timeout for it to fail there faster.

#### What is being changed?

Changed timeout to 1ms on the mentioned tests.

#### How was the change tested?

Tested using an auxiliary branch in the pipeline, test was failing and is passing now.