### PR TITLE
Tool: adding a way to save output to a json file

### DIFF
--- a/samples/tool/SFSClientTool.cpp
+++ b/samples/tool/SFSClientTool.cpp
@@ -308,7 +308,6 @@ void DisplayResults(const json& results)
 {
     if (results.empty())
     {
-        std::cout << "No results found." << std::endl;
         return;
     }
 
@@ -318,6 +317,11 @@ void DisplayResults(const json& results)
 
 Result JSONToFile(const json& results, const std::string& filename)
 {
+    if (results.empty())
+    {
+        return Result::Unexpected;
+    }
+
     const std::filesystem::path filepath = std::filesystem::absolute(filename);
     try
     {
@@ -428,6 +432,12 @@ Result GetLatestDownloadInfo(const SFSClient& sfsClient, const Settings& setting
         }
 
         out = ContentsToJson(contents);
+    }
+
+    if (out.empty())
+    {
+        PrintError("No results found.");
+        return Result::Unexpected;
     }
 
     return Result::Success;

--- a/samples/tool/SFSClientTool.cpp
+++ b/samples/tool/SFSClientTool.cpp
@@ -5,6 +5,7 @@
 
 #include <exception>
 #include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -30,6 +31,7 @@ void DisplayUsage()
         << "Options:" << std::endl
         << "  -h, --help\t\t\tDisplay this help message" << std::endl
         << "  -v, --version\t\t\tDisplay the library version" << std::endl
+        << "  -o, --outputFile <path>\t\tWhen specified, the JSON output is saved to this file" << std::endl
         << "  --isApp\t\t\tIndicates the specific product is an App" << std::endl
         << "  --instanceId <id>\t\tA custom SFS instance ID" << std::endl
         << "  --namespace <ns>\t\tA custom SFS namespace" << std::endl
@@ -87,6 +89,7 @@ struct Settings
     std::string instanceId;
     std::string nameSpace;
     std::string customUrl;
+    std::string outputFile;
 };
 
 void ParseArguments(const std::vector<std::string_view>& args, Settings& settings)
@@ -125,6 +128,11 @@ void ParseArguments(const std::vector<std::string_view>& args, Settings& setting
         else if (matchArg(args[i], "-v", "--version"))
         {
             settings.displayVersion = true;
+        }
+        else if (matchArg(args[i], "-o", "--outputFile"))
+        {
+            validateArg(i, "outputFile", settings.outputFile);
+            settings.outputFile = args[++i];
         }
         else if (matchLongArg(args[i], "--isApp"))
         {
@@ -197,16 +205,8 @@ constexpr std::string_view ToString(Architecture type)
     return "";
 }
 
-void DisplayResults(const std::vector<Content>& contents)
+json ContentsToJson(const std::vector<Content>& contents)
 {
-    if (contents.empty())
-    {
-        PrintError("No results found");
-        return;
-    }
-
-    PrintLog("Content found:");
-
     json out = json::array();
     for (const auto& content : contents)
     {
@@ -233,7 +233,7 @@ void DisplayResults(const std::vector<Content>& contents)
         out.push_back(j);
     }
 
-    PrintLog(out.dump(2 /*indent*/));
+    return out;
 }
 
 json AppFileToJson(const AppFile& file)
@@ -265,16 +265,8 @@ json AppFileToJson(const AppFile& file)
     return fileJson;
 }
 
-void DisplayResults(const std::vector<AppContent>& contents)
+json AppContentsToJson(const std::vector<AppContent>& contents)
 {
-    if (contents.empty())
-    {
-        std::cout << "No results found." << std::endl;
-        return;
-    }
-
-    PrintLog("Content found:");
-
     json out = json::array();
     for (const auto& content : contents)
     {
@@ -309,7 +301,46 @@ void DisplayResults(const std::vector<AppContent>& contents)
         out.push_back(j);
     }
 
-    PrintLog(out.dump(2 /*indent*/));
+    return out;
+}
+
+void DisplayResults(const json& results)
+{
+    if (results.empty())
+    {
+        std::cout << "No results found." << std::endl;
+        return;
+    }
+
+    PrintLog("Content found:");
+    PrintLog(results.dump(2 /*indent*/));
+}
+
+Result JSONToFile(const json& results, const std::string& filename)
+{
+    const std::filesystem::path filepath = std::filesystem::absolute(filename);
+    try
+    {
+        std::filesystem::create_directories(filepath.parent_path());
+    }
+    catch (const std::exception& e)
+    {
+        PrintError("Failed to create parent directories for filepath: " + filepath.string() + ". Error: " + e.what());
+        return Result::Unexpected;
+    }
+
+    std::ofstream file(filepath, std::ios::out | std::ios::trunc);
+    if (!file.is_open())
+    {
+        PrintError("Failed to open file for writing: " + filename);
+        return Result::Unexpected;
+    }
+
+    file << results.dump(2 /*indent*/);
+
+    PrintLog("Content found. Saved to file " + filepath.string());
+
+    return Result::Success;
 }
 
 void LogResult(const SFS::Result& result)
@@ -366,11 +397,12 @@ bool SetEnv(const std::string& varName, const std::string& value)
 #endif
 }
 
-Result GetLatestDownloadInfo(const SFSClient& sfsClient, const Settings& settings)
+Result GetLatestDownloadInfo(const SFSClient& sfsClient, const Settings& settings, json& out)
 {
     PrintLog("Getting latest download info for product: " + settings.product);
     RequestParams params;
     params.productRequests = {{settings.product, {}}};
+
     if (settings.isApp)
     {
         std::vector<AppContent> appContents;
@@ -382,14 +414,12 @@ Result GetLatestDownloadInfo(const SFSClient& sfsClient, const Settings& setting
             return result.GetCode();
         }
 
-        // Display results
-        DisplayResults(appContents);
+        out = AppContentsToJson(appContents);
     }
     else
     {
         std::vector<Content> contents;
         auto result = sfsClient.GetLatestDownloadInfo(params, contents);
-
         if (!result)
         {
             PrintError("Failed to get latest download info.");
@@ -397,8 +427,27 @@ Result GetLatestDownloadInfo(const SFSClient& sfsClient, const Settings& setting
             return result.GetCode();
         }
 
-        // Display results
+        out = ContentsToJson(contents);
+    }
+
+    return Result::Success;
+}
+
+Result HandleJSONContents(const Settings& settings, const json& contents)
+{
+    if (settings.outputFile.empty())
+    {
         DisplayResults(contents);
+        return Result::Success;
+    }
+    else
+    {
+        auto result = JSONToFile(contents, settings.outputFile);
+        if (!result)
+        {
+            PrintError("Failed to save to file.");
+            return result.GetCode();
+        }
     }
 
     return Result::Success;
@@ -465,7 +514,15 @@ int main(int argc, char* argv[])
     }
 
     // Perform operations using SFSClient
-    result = GetLatestDownloadInfo(*sfsClient, settings);
+    json contents;
+    result = GetLatestDownloadInfo(*sfsClient, settings, contents);
+    if (!result)
+    {
+        LogResult(result);
+        return result.GetCode();
+    }
+
+    result = HandleJSONContents(settings, contents);
     if (!result)
     {
         LogResult(result);

--- a/samples/tool/SFSClientTool.cpp
+++ b/samples/tool/SFSClientTool.cpp
@@ -90,6 +90,11 @@ struct Settings
     std::string nameSpace;
     std::string customUrl;
     std::string outputFile;
+
+    bool ShouldOutputToFile() const
+    {
+        return !outputFile.empty();
+    }
 };
 
 void ParseArguments(const std::vector<std::string_view>& args, Settings& settings)
@@ -445,12 +450,7 @@ Result GetLatestDownloadInfo(const SFSClient& sfsClient, const Settings& setting
 
 Result HandleJSONContents(const Settings& settings, const json& contents)
 {
-    if (settings.outputFile.empty())
-    {
-        DisplayResults(contents);
-        return Result::Success;
-    }
-    else
+    if (settings.ShouldOutputToFile())
     {
         auto result = JSONToFile(contents, settings.outputFile);
         if (!result)
@@ -458,6 +458,11 @@ Result HandleJSONContents(const Settings& settings, const json& contents)
             PrintError("Failed to save to file.");
             return result.GetCode();
         }
+    }
+    else
+    {
+        DisplayResults(contents);
+        return Result::Success;
     }
 
     return Result::Success;


### PR DESCRIPTION
#### Related Issues

- Closes #203

#### Why is this change being made?

Adding a capability to save output to a JSON file will make it useful to automate tests with the library by using the tool and checking the output JSON of a given piece of content.

#### What is being changed?

Adding a new switch -o/--outputFile to the client tool, which, when specified, saves the output to a JSON file.

#### How was the change tested?

Running tool locally.