### PR TITLE
Bump curl from 8.4.0 to 8.8.0

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -37,7 +37,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/curl/curl",
-          "commitHash": "d755a5f7c009dd63a61b2c745180d8ba937cbfeb"
+          "commitHash": "fd567d4f06857f4fc8e2f64ea727b1318f76ad33"
         }
       },
       "developmentDependency": false
@@ -56,7 +56,7 @@
           "type": "git",
           "git": {
             "repositoryUrl": "https://github.com/curl/curl",
-            "commitHash": "d755a5f7c009dd63a61b2c745180d8ba937cbfeb"
+            "commitHash": "fd567d4f06857f4fc8e2f64ea727b1318f76ad33"
           }
         }
       ]
@@ -75,7 +75,7 @@
           "type": "git",
           "git": {
             "repositoryUrl": "https://github.com/curl/curl",
-            "commitHash": "d755a5f7c009dd63a61b2c745180d8ba937cbfeb"
+            "commitHash": "fd567d4f06857f4fc8e2f64ea727b1318f76ad33"
           }
         }
       ]

--- a/client/tests/functional/details/CurlConnectionTests.cpp
+++ b/client/tests/functional/details/CurlConnectionTests.cpp
@@ -316,11 +316,11 @@ TEST("Testing a response over the limit fails the operation")
     json body = {{{"TargetingAttributes", {}}, {"Product", largeProductName}}};
     REQUIRE_NOTHROW(connection->Post(url, body.dump()));
 
-    // Over limit fails
+    // Going over the limit fails with a message like "client returned ERROR on write of 16384 bytes"
     body[0]["Product"] = overLimitProductName;
-    REQUIRE_THROWS_CODE_MSG(connection->Post(url, body.dump()),
-                            ConnectionUnexpectedError,
-                            "Failure writing output to destination");
+    REQUIRE_THROWS_CODE_MSG_MATCHES(connection->Post(url, body.dump()),
+                                    ConnectionUnexpectedError,
+                                    Catch::Matchers::ContainsSubstring("client returned ERROR on write of"));
 }
 
 TEST("Testing MS-CV is sent to server")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "curl",
-      "version": "8.4.0"
+      "version": "8.8.0"
     },
     {
       "name": "nlohmann-json",


### PR DESCRIPTION
Address a component governance issue with curl 8.4.0 by updating to the latest release (8.8.0)

CVE-2024-2398
Description of issue:
cURL / libcURL contains a flaw in lib/http2.c that is triggered when handling large amounts of headers. This may allow a remote attacker to consume excessive memory resources and cause a denial of service.


This issue is fixed in the latest release of curl:
https://github.com/curl/curl/releases/tag/curl-8_8_0
Commit used: fd567d4f06857f4fc8e2f64ea727b1318f76ad33
