### PR TITLE
Bump curl from 8.8.0 to 8.9.1

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -37,7 +37,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/curl/curl",
-          "commitHash": "fd567d4f06857f4fc8e2f64ea727b1318f76ad33"
+          "commitHash": "83bedbd730d62b83744cc26fa0433d3f6e2e4cd6"
         }
       },
       "developmentDependency": false
@@ -56,7 +56,7 @@
           "type": "git",
           "git": {
             "repositoryUrl": "https://github.com/curl/curl",
-            "commitHash": "fd567d4f06857f4fc8e2f64ea727b1318f76ad33"
+            "commitHash": "83bedbd730d62b83744cc26fa0433d3f6e2e4cd6"
           }
         }
       ]
@@ -75,7 +75,7 @@
           "type": "git",
           "git": {
             "repositoryUrl": "https://github.com/curl/curl",
-            "commitHash": "fd567d4f06857f4fc8e2f64ea727b1318f76ad33"
+            "commitHash": "83bedbd730d62b83744cc26fa0433d3f6e2e4cd6"
           }
         }
       ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "curl",
-      "version": "8.8.0"
+      "version": "8.9.1"
     },
     {
       "name": "nlohmann-json",


### PR DESCRIPTION
Address another component governance issue: CVE-2024-7264

cURL / libcURL contains an out-of-bounds read flaw in the GTime2str() function in lib/vtls/x509asn1.c that is triggered when parsing a syntactically incorrect ASN.1 Generalized Time field. This may allow a context-dependent attacker to crash a process linked against the library or potentially disclose memory contents.


This is fixed in the latest version of curl (8.9.1)
