### PR TITLE
Setup: improving build tools installation

### DIFF
--- a/.github/workflows/main-build-windows.yml
+++ b/.github/workflows/main-build-windows.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Setup
         shell: pwsh
-        run: .\scripts\Setup.ps1 -NoBuildTools
+        run: .\scripts\Setup.ps1
 
       - name: Build and Test (no test overrides)
         shell: pwsh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup
         shell: pwsh
-        run: .\scripts\Setup.ps1 -NoBuildTools
+        run: .\scripts\Setup.ps1
 
       - name: Check formatting
         shell: pwsh

--- a/scripts/Setup.ps1
+++ b/scripts/Setup.ps1
@@ -12,9 +12,6 @@ Use this on Windows platforms in a PowerShell session.
 .EXAMPLE
 PS> .\scripts\Setup.ps1
 #>
-param (
-    [switch] $NoBuildTools
-)
 
 $ErrorActionPreference = "Stop"
 
@@ -71,19 +68,33 @@ function Install-CMake {
 }
 
 function Install-CppBuildTools {
-    if ($NoBuildTools) {
-        Write-Host -ForegroundColor Yellow "`nSkipping C++ Build Tools installation"
-        return
+    Write-Host -ForegroundColor Cyan "`nInstalling C++ Builds tools if they are not installed"
+
+    # Instaling vswhere, which will be used to query for the required build tools
+    try {
+        vswhere -? 2>&1 | Out-Null
+    }
+    catch {
+        winget install vswhere
+        if (!$?) {
+            Write-Host -ForegroundColor Red "Failed to install vswhere"
+            exit 1
+        }
     }
 
-    Write-Host -ForegroundColor Cyan "`nInstalling C++ Build Tools"
-
     # - Microsoft.VisualStudio.Workload.VCTools is the C++ workload in the Visual Studio Build Tools
-    # --wait makes the install synchronous
-    winget install Microsoft.VisualStudio.2022.BuildTools --silent --override "--wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --remove Microsoft.VisualStudio.Component.VC.CMake.Project"
-    if (!$?) {
-        Write-Host -ForegroundColor Red "Failed to install build tools"
-        exit 1
+    # - Microsoft.VisualStudio.Component.VC.CMake.Project are the C++ CMake tools in the Visual Studio Build Tools
+    $ExistingBuildTools = vswhere -products * -requires Microsoft.VisualStudio.Workload.VCTools Microsoft.VisualStudio.Component.VC.CMake.Project -format json | ConvertFrom-Json
+    if ($null -eq $ExistingBuildTools)
+    {
+        Write-Host "`nTools not found, installing..."
+
+        # --wait makes the install synchronous
+        winget install Microsoft.VisualStudio.2022.BuildTools --silent --override "--wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+        if (!$?) {
+            Write-Host -ForegroundColor Red "Failed to install build tools"
+            exit 1
+        }
     }
 }
 
@@ -93,13 +104,15 @@ function Install-Vcpkg {
     if (!(Test-Path vcpkg)) {
         Write-Host "Cloning vcpkg repo"
         git clone https://github.com/microsoft/vcpkg $GitRoot\vcpkg
-        & "$GitRoot\vcpkg\bootstrap-vcpkg.bat"
     }
     else {
         Write-Host "Checking if vcpkg repo has new commits"
         $NoUpdatesString = "Already up to date."
         git -C "$GitRoot\vcpkg" pull --show-forced-updates | Select-String -Pattern $NoUpdatesString -NotMatch
     }
+
+    # Bootstrapping on every setup updates the vcpkg.exe and solves potential issues with VS Build Tools not being found
+    & "$GitRoot\vcpkg\bootstrap-vcpkg.bat"
 }
 
 function Set-GitHooks {

--- a/scripts/Setup.ps1
+++ b/scripts/Setup.ps1
@@ -83,7 +83,8 @@ function Install-CppBuildTools {
     }
 
     # - Microsoft.VisualStudio.Workload.VCTools is the C++ workload in the Visual Studio Build Tools
-    $ExistingBuildTools = vswhere -products * -requires Microsoft.VisualStudio.Workload.VCTools -format json | ConvertFrom-Json
+    # - Microsoft.VisualStudio.Workload.NativeDesktop is the C++ workload that comes pre-installed in the github runner image
+    $ExistingBuildTools = vswhere -products * -requires Microsoft.VisualStudio.Workload.VCTools Microsoft.VisualStudio.Workload.NativeDesktop -requiresAny -format json | ConvertFrom-Json
     if ($null -eq $ExistingBuildTools)
     {
         Write-Host "`nTools not found, installing..."

--- a/scripts/Setup.ps1
+++ b/scripts/Setup.ps1
@@ -83,14 +83,13 @@ function Install-CppBuildTools {
     }
 
     # - Microsoft.VisualStudio.Workload.VCTools is the C++ workload in the Visual Studio Build Tools
-    # - Microsoft.VisualStudio.Component.VC.CMake.Project are the C++ CMake tools in the Visual Studio Build Tools
-    $ExistingBuildTools = vswhere -products * -requires Microsoft.VisualStudio.Workload.VCTools Microsoft.VisualStudio.Component.VC.CMake.Project -format json | ConvertFrom-Json
+    $ExistingBuildTools = vswhere -products * -requires Microsoft.VisualStudio.Workload.VCTools -format json | ConvertFrom-Json
     if ($null -eq $ExistingBuildTools)
     {
         Write-Host "`nTools not found, installing..."
 
         # --wait makes the install synchronous
-        winget install Microsoft.VisualStudio.2022.BuildTools --silent --override "--wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+        winget install Microsoft.VisualStudio.2022.BuildTools --silent --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --remove Microsoft.VisualStudio.Component.VC.CMake.Project"
         if (!$?) {
             Write-Host -ForegroundColor Red "Failed to install build tools"
             exit 1


### PR DESCRIPTION
#### Related Issues

- Closes #197

#### Why is this change being made?

I went to run setup & build after some time not using cmake and faced an issue with my build tools not being found.
Running setup again did not help either. Turns out I had to manually call vcpkg bootstrap so it set up the latest build tools on its folder so it could be found.

#### What is being changed?

- Installing vswhere and using it to auto-detect during the setup script there are currently installed VS build tools with the required C++ build components.
- Using `--quiet` to make the installation silent.
- Calling vcpkg bootstrap on all setup runs to avoid these kinds of issues.
- `-NoBuildTools` is no longer needed.

#### How was the change tested?

- Not a functional change. Modifying auxiliary files.
- Ran the setup script a few times locally to test it. It's no longer installing build tools if they're not needed.
