### PR TITLE
Adding support for a custom proxy input

### DIFF
--- a/client/include/sfsclient/RequestParams.h
+++ b/client/include/sfsclient/RequestParams.h
@@ -35,6 +35,11 @@ struct RequestParams
     /// @note If not provided, a new CorrelationVector will be generated
     std::optional<std::string> baseCV;
 
+    /// @brief Proxy setting which can be used to establish connections with the server (optional)
+    /// @note The string can be a hostname or dotted numerical IP address. It can be suffixed with the port number
+    /// like :[port], and can be prefixed with [scheme]://. If not provided, no proxy will be used.
+    std::optional<std::string> proxy;
+
     /// @brief Retry for a web request after a failed attempt. If true, client will retry up to c_maxRetries times
     bool retryOnError{true};
 };

--- a/client/src/details/UrlBuilder.cpp
+++ b/client/src/details/UrlBuilder.cpp
@@ -76,19 +76,19 @@ std::string UrlBuilder::GetPath() const
 
 std::string UrlBuilder::GetQuery() const
 {
-    std::string ret;
     CurlCharPtr query;
     char* queryPtr = query.get();
     const auto queryResult = curl_url_get(m_handle, CURLUPART_QUERY, &queryPtr, 0 /*flags*/);
-    if (queryResult == CURLUE_OK)
+    switch (queryResult)
     {
-        ret = queryPtr;
-    }
-    else if (queryResult != CURLUE_NO_QUERY)
-    {
+    case CURLUE_OK:
+        return queryPtr;
+    case CURLUE_NO_QUERY:
+        return {};
+    default:
         THROW_IF_CURL_URL_SETUP_ERROR(queryResult);
     }
-    return ret;
+    return {};
 }
 
 UrlBuilder& UrlBuilder::SetScheme(Scheme scheme)

--- a/client/src/details/UrlBuilder.cpp
+++ b/client/src/details/UrlBuilder.cpp
@@ -66,6 +66,31 @@ std::string UrlBuilder::GetUrl() const
     return urlPtr;
 }
 
+std::string UrlBuilder::GetPath() const
+{
+    CurlCharPtr path;
+    char* pathPtr = path.get();
+    THROW_IF_CURL_URL_SETUP_ERROR(curl_url_get(m_handle, CURLUPART_PATH, &pathPtr, 0 /*flags*/));
+    return pathPtr;
+}
+
+std::string UrlBuilder::GetQuery() const
+{
+    std::string ret;
+    CurlCharPtr query;
+    char* queryPtr = query.get();
+    const auto queryResult = curl_url_get(m_handle, CURLUPART_QUERY, &queryPtr, 0 /*flags*/);
+    if (queryResult == CURLUE_OK)
+    {
+        ret = queryPtr;
+    }
+    else if (queryResult != CURLUE_NO_QUERY)
+    {
+        THROW_IF_CURL_URL_SETUP_ERROR(queryResult);
+    }
+    return ret;
+}
+
 UrlBuilder& UrlBuilder::SetScheme(Scheme scheme)
 {
     switch (scheme)

--- a/client/src/details/UrlBuilder.h
+++ b/client/src/details/UrlBuilder.h
@@ -39,6 +39,9 @@ class UrlBuilder
 
     std::string GetUrl() const;
 
+    std::string GetPath() const;
+    std::string GetQuery() const;
+
     /**
      * @brief Set the scheme for the URL
      * @param scheme The scheme to set for the URL Ex: Https

--- a/client/src/details/connection/ConnectionConfig.cpp
+++ b/client/src/details/connection/ConnectionConfig.cpp
@@ -11,5 +11,6 @@ using namespace SFS::details;
 ConnectionConfig::ConnectionConfig(const SFS::RequestParams& requestParams)
     : maxRetries(requestParams.retryOnError ? c_maxRetries : 0)
     , baseCV(requestParams.baseCV)
+    , proxy(requestParams.proxy)
 {
 }

--- a/client/src/details/connection/ConnectionConfig.h
+++ b/client/src/details/connection/ConnectionConfig.h
@@ -22,6 +22,9 @@ struct ConnectionConfig
 
     /// @brief The correlation vector to use for requests
     std::optional<std::string> baseCV;
+
+    /// @brief Proxy setting which can be used to establish connections with the server
+    std::optional<std::string> proxy;
 };
 } // namespace details
 } // namespace SFS

--- a/client/src/details/connection/CurlConnection.cpp
+++ b/client/src/details/connection/CurlConnection.cpp
@@ -284,6 +284,11 @@ CurlConnection::CurlConnection(const ConnectionConfig& config, const ReportingHa
                           m_handler,
                           "Failed to set up curl");
 
+    if (config.proxy)
+    {
+        THROW_IF_CURL_SETUP_ERROR(curl_easy_setopt(m_handle, CURLOPT_PROXY, config.proxy->c_str()));
+    }
+
     // TODO #41: Pass AAD token in the header if it is available
     // TODO #42: Cert pinning with service
 }

--- a/client/tests/CMakeLists.txt
+++ b/client/tests/CMakeLists.txt
@@ -17,6 +17,8 @@ target_sources(
             functional/details/SFSClientImplTests.cpp
             functional/SFSClientTests.cpp
             mock/MockWebServer.cpp
+            mock/ProxyServer.cpp
+            mock/ServerCommon.cpp
             unit/AppContentTests.cpp
             unit/AppFileTests.cpp
             unit/ApplicabilityDetailsTests.cpp

--- a/client/tests/functional/SFSClientTests.cpp
+++ b/client/tests/functional/SFSClientTests.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "../mock/MockWebServer.h"
+#include "../mock/ProxyServer.h"
 #include "../util/TestHelper.h"
 #include "TestOverride.h"
 #include "sfsclient/SFSClient.h"
@@ -112,6 +113,19 @@ TEST("Testing SFSClient::GetLatestDownloadInfo()")
             CheckMockContent(contents[0], c_version);
         }
 
+        SECTION("No attributes + proxy")
+        {
+            test::ProxyServer proxy;
+
+            params.productRequests = {{c_productName, {}}};
+            params.proxy = proxy.GetBaseUrl();
+            REQUIRE(sfsClient->GetLatestDownloadInfo(params, contents) == Result::Success);
+            REQUIRE(contents.size() == 1);
+            CheckMockContent(contents[0], c_version);
+
+            REQUIRE(proxy.Stop() == Result::Success);
+        }
+
         SECTION("With attributes")
         {
             const TargetingAttributes attributes{{"attr1", "value"}};
@@ -143,6 +157,8 @@ TEST("Testing SFSClient::GetLatestDownloadInfo()")
             CheckMockContent(contents[0], c_nextVersion);
         }
     }
+
+    REQUIRE(server.Stop() == Result::Success);
 }
 
 TEST("Testing SFSClient::GetLatestAppDownloadInfo()")
@@ -244,6 +260,8 @@ TEST("Testing SFSClient::GetLatestAppDownloadInfo()")
                 "Unexpected content type [Generic] returned by the service does not match the expected [App]");
         REQUIRE(contents.empty());
     }
+
+    REQUIRE(server.Stop() == Result::Success);
 }
 
 TEST("Testing SFSClient retry behavior")
@@ -437,4 +455,6 @@ TEST("Testing SFSClient retry behavior")
             }
         }
     }
+
+    REQUIRE(server.Stop() == Result::Success);
 }

--- a/client/tests/mock/ProxyServer.cpp
+++ b/client/tests/mock/ProxyServer.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "ProxyServer.h"
+
+#include "../util/TestHelper.h"
+#include "ErrorHandling.h"
+#include "ReportingHandler.h"
+#include "ServerCommon.h"
+#include "UrlBuilder.h"
+
+using namespace SFS;
+using namespace SFS::details;
+using namespace SFS::test;
+using namespace SFS::test::details;
+
+namespace SFS::test::details
+{
+class ProxyServerImpl : public BaseServerImpl
+{
+  private:
+    void ConfigureRequestHandlers() override;
+    std::string GetLogIdentifier() override;
+};
+} // namespace SFS::test::details
+
+ProxyServer::ProxyServer()
+{
+    m_impl = std::make_unique<ProxyServerImpl>();
+    m_impl->Start();
+}
+
+ProxyServer::~ProxyServer()
+{
+    const auto ret = Stop();
+    if (!ret)
+    {
+        TEST_UNSCOPED_INFO("Failed to stop: " + std::string(ToString(ret.GetCode())));
+    }
+}
+
+Result ProxyServer::Stop()
+{
+    return m_impl->Stop();
+}
+
+std::string ProxyServer::GetBaseUrl() const
+{
+    return m_impl->GetUrl();
+}
+
+void ProxyServerImpl::ConfigureRequestHandlers()
+{
+    auto HandleRequest = [&](const httplib::Request& req, httplib::Response& res) {
+        // As a proxy, we'll parse the URL and Path/Query so we can reuse them in httplib::Client
+        ReportingHandler handler;
+        UrlBuilder urlBuilder(req.target.c_str(), handler);
+        const std::string path = urlBuilder.GetPath();
+        const std::string query = urlBuilder.GetQuery();
+        urlBuilder.ResetPath().ResetQuery();
+
+        // URL may come back from UrlBuilder with a final /, which doesn't work with httplib::Client, so we remove it
+        auto url = urlBuilder.GetUrl();
+        if (url.at(url.size() - 1) == '/')
+        {
+            url.pop_back();
+        }
+        const std::string pathAndQuery = path + (query.empty() ? "" : ("?" + query));
+        httplib::Client cli(url);
+        httplib::Result result;
+        if (req.method == "GET")
+        {
+            result = cli.Get(pathAndQuery, req.headers);
+        }
+        else if (req.method == "POST")
+        {
+            const auto length = std::stoi(req.get_header_value("Content-Length"));
+            result =
+                cli.Post(pathAndQuery, req.headers, req.body.c_str(), length, req.get_header_value("Content-Type"));
+        }
+
+        if (!result)
+        {
+            BUFFER_LOG("Client error: " + to_string(result.error()));
+            throw StatusCodeException(httplib::StatusCode::InternalServerError_500);
+        }
+        res = result.value();
+    };
+
+    m_server.Get(".*", HandleRequest);
+    m_server.Post(".*", HandleRequest);
+}
+
+std::string ProxyServerImpl::GetLogIdentifier()
+{
+    return "ProxyServer";
+}

--- a/client/tests/mock/ProxyServer.h
+++ b/client/tests/mock/ProxyServer.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "Result.h"
+
+#include <memory>
+
+namespace SFS::test
+{
+namespace details
+{
+class ProxyServerImpl;
+}
+
+// Proxy Server implementation that redirects GET and POST requests directly
+class ProxyServer
+{
+  public:
+    ProxyServer();
+    ~ProxyServer();
+
+    ProxyServer(const ProxyServer&) = delete;
+    ProxyServer& operator=(const ProxyServer&) = delete;
+
+    Result Stop();
+
+    std::string GetBaseUrl() const;
+
+  private:
+    std::unique_ptr<details::ProxyServerImpl> m_impl;
+};
+} // namespace SFS::test

--- a/client/tests/mock/ServerCommon.cpp
+++ b/client/tests/mock/ServerCommon.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "ServerCommon.h"
+
+#include "../util/TestHelper.h"
+#include "Result.h"
+
+using SFS::test::BufferedLogData;
+using SFS::test::StatusCodeException;
+using SFS::test::details::BaseServerImpl;
+using namespace SFS;
+using namespace std::string_literals;
+
+static constexpr const char* c_listenHostName = "localhost";
+
+static std::string ToString(httplib::StatusCode status)
+{
+    return std::to_string(status) + " " + std::string(httplib::status_message(status));
+}
+
+StatusCodeException::StatusCodeException(httplib::StatusCode status) : m_status(status)
+{
+}
+
+const char* StatusCodeException::what() const noexcept
+{
+    return ::ToString(m_status).c_str();
+}
+
+httplib::StatusCode StatusCodeException::GetStatusCode() const
+{
+    return m_status;
+}
+
+static SFS::LogData ToLogData(const BufferedLogData& data)
+{
+    return {LogSeverity::Info, data.message.c_str(), data.file.c_str(), data.line, data.function.c_str(), data.time};
+}
+
+void BaseServerImpl::Start()
+{
+    ConfigureServerSettings();
+    ConfigureRequestHandlers();
+
+    m_port = m_server.bind_to_any_port(c_listenHostName);
+    m_listenerThread = std::thread([&]() { m_server.listen_after_bind(); });
+}
+
+void BaseServerImpl::ConfigureServerSettings()
+{
+    m_server.set_logger([&](const httplib::Request& req, const httplib::Response& res) {
+        BUFFER_LOG("Request: " + req.method + " " + req.path + " " + req.version);
+        BUFFER_LOG("Request Body: " + req.body);
+
+        BUFFER_LOG("Response: " + res.version + " " + ::ToString(static_cast<httplib::StatusCode>(res.status)) + " " +
+                   res.reason);
+        BUFFER_LOG("Response body: " + res.body);
+    });
+
+    m_server.set_exception_handler([&](const httplib::Request&, httplib::Response& res, std::exception_ptr ep) {
+        try
+        {
+            std::rethrow_exception(ep);
+        }
+        catch (std::exception& e)
+        {
+            m_lastException = Result(Result::HttpUnexpected, e.what());
+        }
+        catch (...)
+        {
+            m_lastException = Result(Result::HttpUnexpected, "Unknown Exception");
+        }
+
+        ProcessBufferedLogs();
+
+        res.status = httplib::StatusCode::InternalServerError_500;
+    });
+
+    // Keeping this interval to a minimum ensures tests run quicker
+    m_server.set_keep_alive_timeout(1); // 1 second
+}
+
+void BaseServerImpl::BufferLog(const BufferedLogData& data)
+{
+    std::lock_guard guard(m_logMutex);
+    m_bufferedLog.push_back(data);
+}
+
+BufferedLogData BaseServerImpl::BuildBufferedLogData(const std::string& message,
+                                                     const char* file,
+                                                     unsigned line,
+                                                     const char* function)
+{
+    return BufferedLogData{GetLogIdentifier() + ": " + message, file, line, function, std::chrono::system_clock::now()};
+}
+
+void BaseServerImpl::ProcessBufferedLogs()
+{
+    for (const auto& data : m_bufferedLog)
+    {
+        LogCallbackToTest(ToLogData(data));
+    }
+    m_bufferedLog.clear();
+}
+
+Result BaseServerImpl::Stop()
+{
+    if (m_listenerThread.joinable())
+    {
+        m_server.stop();
+        m_listenerThread.join();
+    }
+    ProcessBufferedLogs();
+    return m_lastException.value_or(Result::Success);
+}
+
+std::string BaseServerImpl::GetUrl() const
+{
+    return "http://"s + c_listenHostName + ":"s + std::to_string(m_port);
+}

--- a/client/tests/mock/ServerCommon.cpp
+++ b/client/tests/mock/ServerCommon.cpp
@@ -19,13 +19,13 @@ static std::string ToString(httplib::StatusCode status)
     return std::to_string(status) + " " + std::string(httplib::status_message(status));
 }
 
-StatusCodeException::StatusCodeException(httplib::StatusCode status) : m_status(status)
+StatusCodeException::StatusCodeException(httplib::StatusCode status) : m_status(status), m_message(::ToString(m_status))
 {
 }
 
 const char* StatusCodeException::what() const noexcept
 {
-    return ::ToString(m_status).c_str();
+    return m_message.c_str();
 }
 
 httplib::StatusCode StatusCodeException::GetStatusCode() const

--- a/client/tests/mock/ServerCommon.h
+++ b/client/tests/mock/ServerCommon.h
@@ -25,6 +25,7 @@ class StatusCodeException : public std::exception
 
   private:
     httplib::StatusCode m_status;
+    std::string m_message;
 };
 
 #define BUILD_BUFFERED_LOG_DATA(message) BuildBufferedLogData(message, __FILE__, __LINE__, __FUNCTION__)

--- a/client/tests/mock/ServerCommon.h
+++ b/client/tests/mock/ServerCommon.h
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "Logging.h"
+#include "Result.h"
+
+#include <httplib.h>
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+namespace SFS::test
+{
+class StatusCodeException : public std::exception
+{
+  public:
+    StatusCodeException(httplib::StatusCode status);
+
+    const char* what() const noexcept override;
+
+    httplib::StatusCode GetStatusCode() const;
+
+  private:
+    httplib::StatusCode m_status;
+};
+
+#define BUILD_BUFFERED_LOG_DATA(message) BuildBufferedLogData(message, __FILE__, __LINE__, __FUNCTION__)
+
+#define BUFFER_LOG(message) BufferLog(BUILD_BUFFERED_LOG_DATA(message))
+
+struct BufferedLogData
+{
+    std::string message;
+    std::string file;
+    unsigned line;
+    std::string function;
+    std::chrono::time_point<std::chrono::system_clock> time;
+};
+
+namespace details
+{
+class BaseServerImpl
+{
+  public:
+    BaseServerImpl() = default;
+    ~BaseServerImpl() = default;
+
+    BaseServerImpl(const BaseServerImpl&) = delete;
+    BaseServerImpl& operator=(const BaseServerImpl&) = delete;
+
+    void Start();
+    Result Stop();
+
+    std::string GetUrl() const;
+
+  protected:
+    void ConfigureServerSettings();
+    virtual void ConfigureRequestHandlers() = 0;
+
+    virtual std::string GetLogIdentifier() = 0;
+
+    void BufferLog(const BufferedLogData& data);
+    BufferedLogData BuildBufferedLogData(const std::string& message,
+                                         const char* file,
+                                         unsigned line,
+                                         const char* function);
+    void ProcessBufferedLogs();
+
+    httplib::Server m_server;
+    int m_port{-1};
+
+    std::optional<Result> m_lastException;
+
+    std::thread m_listenerThread;
+
+    std::vector<BufferedLogData> m_bufferedLog;
+    std::mutex m_logMutex;
+};
+} // namespace details
+} // namespace SFS::test

--- a/client/tests/unit/SFSClientTests.cpp
+++ b/client/tests/unit/SFSClientTests.cpp
@@ -261,6 +261,44 @@ void TestProductInRequestParams(const std::function<Result(const RequestParams&)
         REQUIRE(result.GetMsg().find("baseCV is not a valid correlation vector:") == 0);
         checkContents();
     }
+
+    SECTION("Fails if proxy is setup incorrectly")
+    {
+        params.productRequests = {{"p1", {}}};
+        params.proxy = "bad://";
+        auto result = apiCall(params);
+        REQUIRE(result.GetCode() == Result::ConnectionUnexpectedError);
+        REQUIRE(result.GetMsg() == "Unsupported proxy syntax in 'bad://': No host part in the URL");
+        checkContents();
+
+        params.proxy = "bad://bad.com";
+        result = apiCall(params);
+        REQUIRE(result.GetCode() == Result::ConnectionUnexpectedError);
+        REQUIRE(result.GetMsg() == "Unsupported proxy scheme for 'bad://bad.com'");
+        checkContents();
+
+        params.proxy = ":";
+        result = apiCall(params);
+        REQUIRE(result.GetCode() == Result::ConnectionUnexpectedError);
+        REQUIRE(result.GetMsg() ==
+                "Unsupported proxy syntax in ':': Port number was not a decimal number between 0 and 65535");
+        checkContents();
+
+        params.proxy = "http://bad:bad";
+        result = apiCall(params);
+        REQUIRE(result.GetCode() == Result::ConnectionUnexpectedError);
+        REQUIRE(
+            result.GetMsg() ==
+            "Unsupported proxy syntax in 'http://bad:bad': Port number was not a decimal number between 0 and 65535");
+        checkContents();
+
+        params.proxy = "bad:bad";
+        result = apiCall(params);
+        REQUIRE(result.GetCode() == Result::ConnectionUnexpectedError);
+        REQUIRE(result.GetMsg() ==
+                "Unsupported proxy syntax in 'bad:bad': Port number was not a decimal number between 0 and 65535");
+        checkContents();
+    }
 }
 } // namespace
 


### PR DESCRIPTION
#### Related Issues

- Closes #217

#### Why is this change being made?

WinGet has a feature where a user can specify a proxy string. Some users of winget download are interested in using the feature so they can use a proxy to bypass enterprise blocking of the service URL, and sfs client would need to support the proxy string in its network connection layer.

For the curl implementation inside the client, that means passing in a string to CURLOPT_PROXY setting.

This PR is implementing support for a new input parameter for a request to supply a custom proxy.

#### What is being changed?

- A caller can now specify a `std::optional<std::string> proxy` argument on `requestParams` in the Client APIs. The correspondent request will use that proxy when connecting to the service to get product information.
- The implementation happens in the Curl connection layer, where the `proxy` string is passed to `CURLOPT_PROXY` setting
- For testing:
  - I've implemented a simple `ProxyServer` class reusing the model for the `MockWebServer` class and the cpp-httplib library. It just redirects GET and POST requests to the original server target URL.
  - I've added unit tests for validating that CURL accepts only valid proxy strings.
  - I've added functional tests using the new proxy server.

#### How was the change tested?

New tests are being added as mentioned above.
