### PR TITLE
Improve logging when the content type is wrong

### DIFF
--- a/client/src/details/entity/ContentType.cpp
+++ b/client/src/details/entity/ContentType.cpp
@@ -3,16 +3,9 @@
 
 #include "ContentType.h"
 
-#include "../ErrorHandling.h"
-#include "../ReportingHandler.h"
-#include "Result.h"
-
-using namespace SFS;
 using namespace SFS::details;
 
-namespace
-{
-std::string ToString(ContentType type)
+std::string SFS::details::ToString(ContentType type)
 {
     switch (type)
     {
@@ -23,16 +16,4 @@ std::string ToString(ContentType type)
     default:
         return "Unknown";
     }
-}
-} // namespace
-
-void SFS::details::ValidateContentType(ContentType currentType,
-                                       ContentType expectedType,
-                                       const ReportingHandler& handler)
-{
-    THROW_CODE_IF_LOG(Result::ServiceUnexpectedContentType,
-                      currentType != expectedType,
-                      handler,
-                      "Unexpected content type [" + ::ToString(currentType) +
-                          "] returned by the service does not match the expected [" + ::ToString(expectedType) + "]");
 }

--- a/client/src/details/entity/ContentType.h
+++ b/client/src/details/entity/ContentType.h
@@ -3,15 +3,15 @@
 
 #pragma once
 
+#include <string>
+
 namespace SFS::details
 {
-class ReportingHandler;
-
 enum class ContentType
 {
     Generic,
     App,
 };
 
-void ValidateContentType(ContentType currentType, ContentType expectedType, const ReportingHandler& handler);
+std::string ToString(ContentType type);
 } // namespace SFS::details

--- a/client/src/details/entity/FileEntity.cpp
+++ b/client/src/details/entity/FileEntity.cpp
@@ -66,6 +66,16 @@ Architecture ArchitectureFromString(const std::string& arch, const ReportingHand
         return Architecture::None; // Unreachable code, but the compiler doesn't know that.
     }
 }
+
+void ValidateContentType(const FileEntity& entity, ContentType expectedType, const ReportingHandler& handler)
+{
+    THROW_CODE_IF_LOG(Result::ServiceUnexpectedContentType,
+                      entity.GetContentType() != expectedType,
+                      handler,
+                      "The service returned file \"" + entity.fileId + "\" with content type [" +
+                          ToString(entity.GetContentType()) + "] while the expected type was [" +
+                          ToString(expectedType) + "]");
+}
 } // namespace
 
 std::unique_ptr<FileEntity> FileEntity::FromJson(const nlohmann::json& file, const ReportingHandler& handler)
@@ -204,7 +214,7 @@ ContentType GenericFileEntity::GetContentType() const
 
 std::unique_ptr<File> GenericFileEntity::ToFile(FileEntity&& entity, const ReportingHandler& handler)
 {
-    ValidateContentType(entity.GetContentType(), ContentType::Generic, handler);
+    ValidateContentType(entity, ContentType::Generic, handler);
 
     std::unordered_map<HashType, std::string> hashes;
     for (auto& [hashType, hashValue] : entity.hashes)
@@ -237,7 +247,7 @@ ContentType AppFileEntity::GetContentType() const
 
 std::unique_ptr<AppFile> AppFileEntity::ToAppFile(FileEntity&& entity, const ReportingHandler& handler)
 {
-    ValidateContentType(entity.GetContentType(), ContentType::App, handler);
+    ValidateContentType(entity, ContentType::App, handler);
 
     auto appEntity = dynamic_cast<AppFileEntity&&>(entity);
 

--- a/client/src/details/entity/VersionEntity.cpp
+++ b/client/src/details/entity/VersionEntity.cpp
@@ -16,6 +16,19 @@ using namespace SFS;
 using namespace SFS::details;
 using json = nlohmann::json;
 
+namespace
+{
+void ValidateContentType(const VersionEntity& entity, ContentType expectedType, const ReportingHandler& handler)
+{
+    THROW_CODE_IF_LOG(Result::ServiceUnexpectedContentType,
+                      entity.GetContentType() != expectedType,
+                      handler,
+                      "The service returned entity \"" + entity.contentId.name + "\" with content type [" +
+                          ToString(entity.GetContentType()) + "] while the expected type was [" +
+                          ToString(expectedType) + "]");
+}
+} // namespace
+
 std::unique_ptr<VersionEntity> VersionEntity::FromJson(const nlohmann::json& data, const ReportingHandler& handler)
 {
     // Expected format for a generic version entity:
@@ -135,6 +148,6 @@ ContentType AppVersionEntity::GetContentType() const
 AppVersionEntity* AppVersionEntity::GetAppVersionEntityPtr(std::unique_ptr<VersionEntity>& versionEntity,
                                                            const ReportingHandler& handler)
 {
-    ValidateContentType(versionEntity->GetContentType(), ContentType::App, handler);
+    ValidateContentType(*versionEntity, ContentType::App, handler);
     return dynamic_cast<AppVersionEntity*>(versionEntity.get());
 }

--- a/client/tests/functional/SFSClientTests.cpp
+++ b/client/tests/functional/SFSClientTests.cpp
@@ -240,8 +240,9 @@ TEST("Testing SFSClient::GetLatestAppDownloadInfo()")
         params.productRequests = {{c_productName, {}}};
         auto result = sfsClient->GetLatestAppDownloadInfo(params, contents);
         REQUIRE(result.GetCode() == Result::ServiceUnexpectedContentType);
-        REQUIRE(result.GetMsg() ==
-                "Unexpected content type [Generic] returned by the service does not match the expected [App]");
+        REQUIRE(
+            result.GetMsg() ==
+            R"(The service returned entity "testProduct" with content type [Generic] while the expected type was [App])");
         REQUIRE(contents.empty());
     }
 }

--- a/client/tests/unit/details/entity/FileEntityTests.cpp
+++ b/client/tests/unit/details/entity/FileEntityTests.cpp
@@ -369,7 +369,7 @@ TEST("Testing GenericFileEntity conversions")
             REQUIRE_THROWS_CODE_MSG(
                 GenericFileEntity::ToFile(std::move(*wrongEntity), handler),
                 ServiceUnexpectedContentType,
-                "Unexpected content type [App] returned by the service does not match the expected [Generic]");
+                R"(The service returned file "fileId" with content type [App] while the expected type was [Generic])");
         }
     }
 
@@ -423,7 +423,7 @@ TEST("Testing GenericFileEntity conversions")
             REQUIRE_THROWS_CODE_MSG(
                 GenericFileEntity::FileEntitiesToFileVector(std::move(wrongEntities), handler),
                 ServiceUnexpectedContentType,
-                "Unexpected content type [App] returned by the service does not match the expected [Generic]");
+                R"(The service returned file "fileId" with content type [App] while the expected type was [Generic])");
         }
     }
 }
@@ -475,7 +475,7 @@ TEST("Testing AppFileEntity conversions")
             REQUIRE_THROWS_CODE_MSG(
                 AppFileEntity::ToAppFile(std::move(*wrongEntity), handler),
                 ServiceUnexpectedContentType,
-                "Unexpected content type [Generic] returned by the service does not match the expected [App]");
+                R"(The service returned file "fileId" with content type [Generic] while the expected type was [App])");
         }
     }
 
@@ -535,7 +535,7 @@ TEST("Testing AppFileEntity conversions")
             REQUIRE_THROWS_CODE_MSG(
                 AppFileEntity::FileEntitiesToAppFileVector(std::move(wrongEntities), handler),
                 ServiceUnexpectedContentType,
-                "Unexpected content type [Generic] returned by the service does not match the expected [App]");
+                R"(The service returned file "fileId" with content type [Generic] while the expected type was [App])");
         }
     }
 }


### PR DESCRIPTION
#### Related Issues

- Closes #208

#### Why is this change being made?

In the mentioned issue, an acquisition failed in a scan from winget because one of the files of a piece of content did not have the "FileMoniker" field. The logs don't say which file failed validation, they just say something was not of the App type.

#### What is being changed?

Adding more information about the entity that failed content type validation on the log messages.

#### How was the change tested?

File and Version entity tests were modified to check for the new message.
