### PR TITLE
Bumping version to 1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 # 1. MAJOR version when you make incompatible API changes
 # 2. MINOR version when you add functionality in a backward compatible manner
 # 3. PATCH version when you make backward compatible bug fixes
-set(SFS_LIBRARY_VERSION "1.0.0")
+set(SFS_LIBRARY_VERSION "1.1.0")
 
 project(
     sfsclient


### PR DESCRIPTION
#### Related Issues

- Closes #219

#### Why is this change being made?

Releasing a minor version with proxy support.

#### What is being changed?

Bumping library version to 1.1.0

#### How was the change tested?

- Not a functional change. Ex: modifying documentation, auxiliary files, etc
