### PR TITLE
Fixing spelling issues within the codebase

### DIFF
--- a/API.md
+++ b/API.md
@@ -27,7 +27,7 @@ void LoggingCallback(const SFS::LogData& logData)
 Notes:
 - The callback itself is processed in the main thread. Do not use a blocking callback. If heavy processing has to be done, consider capturing the data and processing another thread.
 - The LogData contents only exist within the callback call. If the processing will be done later, you should copy the data elsewhere.
-- The callback should not do any re-entrant calls (e.g. call `SFSClient` methods).
+- The callback should not do any reentrant calls (e.g. call `SFSClient` methods).
 
 ## Class instances
 

--- a/TEST.md
+++ b/TEST.md
@@ -2,7 +2,7 @@
 
 Some test behaviors are controlled by test overrides set via environment variables.
 They only work when the CMake Option `SFS_ENABLE_TEST_OVERRIDES` is set to `ON`.
-To enable that during build, you must use the switch `-EnableTestOverrides` (`--enable-test-overrides` on Linux) with the build scripts. See [building](README.md#building) for more information. See also [here](README.md#building-with-cmake-vscode-extension) for how to set when using VSCode.
+To enable that during build, you must use the switch `-EnableTestOverrides` (`--enable-test-overrides` on Linux) with the build scripts. See [building](README.md#building) for more information. See also [building with cmake vscode extension](README.md#building-with-cmake-vscode-extension) for how to set when using VSCode.
 
 When the test overrides are enabled, a few environment variables can be used to adjust the behavior of the tool:
 

--- a/TEST.md
+++ b/TEST.md
@@ -2,7 +2,7 @@
 
 Some test behaviors are controlled by test overrides set via environment variables.
 They only work when the CMake Option `SFS_ENABLE_TEST_OVERRIDES` is set to `ON`.
-To enable that during build, you must use the switch `-EnableTestOverrides` (`--enable-test-overrides` on Linux) with the build scripts. Click [here](README.md#building) for more. See also [here](README.md#building-with-cmake-vscode-extension) for how to set when using VSCode.
+To enable that during build, you must use the switch `-EnableTestOverrides` (`--enable-test-overrides` on Linux) with the build scripts. See [building](README.md#building) for more information. See also [here](README.md#building-with-cmake-vscode-extension) for how to set when using VSCode.
 
 When the test overrides are enabled, a few environment variables can be used to adjust the behavior of the tool:
 

--- a/client/include/sfsclient/AppContent.h
+++ b/client/include/sfsclient/AppContent.h
@@ -30,7 +30,7 @@ class AppPrerequisiteContent
     const ContentId& GetContentId() const noexcept;
 
     /**
-     * @return Files belonging to this Prequisite
+     * @return Files belonging to this Prerequisite
      */
     const std::vector<AppFile>& GetFiles() const noexcept;
 

--- a/client/include/sfsclient/ClientConfig.h
+++ b/client/include/sfsclient/ClientConfig.h
@@ -24,10 +24,11 @@ struct ClientConfig
 
     /**
      * @brief A logging callback function that is called when the SFSClient logs a message
-     * @details This function returns logging information from the SFSClient. The caller is responsible for incoporating
-     * the received data into their logging system. The callback will be called in the same thread as the
-     * main flow, so make sure the callback does not block for too long so it doesn't delay operations. The
-     * LogData does not exist after the callback returns, so caller has to copy it if the data will be stored.
+     * @details This function returns logging information from the SFSClient. The caller is responsible for
+     * incorporating the received data into their logging system. The callback will be called in the same
+     * thread as the main flow, so make sure the callback does not block for too long so it doesn't delay
+     * operations. The LogData does not exist after the callback returns, so caller has to copy it if the
+     * data will be stored.
      */
     std::optional<LoggingCallbackFn> logCallbackFn;
 };

--- a/client/src/details/connection/CurlConnection.cpp
+++ b/client/src/details/connection/CurlConnection.cpp
@@ -417,7 +417,7 @@ void CurlConnection::ProcessRetry(int attempt, const Result& httpResult)
 
         std::chrono::milliseconds baseRetryDelay = s_baseRetryDelay;
 
-        // Value can be overriden in tests
+        // Value can be overridden in tests
         if (auto override = test::GetTestOverrideAsInt(test::TestOverride::BaseRetryDelayMs))
         {
             baseRetryDelay = std::chrono::milliseconds{*override};

--- a/client/tests/functional/details/CurlConnectionTests.cpp
+++ b/client/tests/functional/details/CurlConnectionTests.cpp
@@ -255,7 +255,7 @@ TEST("Testing CurlConnection()")
         REQUIRE_THROWS_CODE(connection->Post(url + "/names", "{}"), HttpNotFound);
 
         url = server.GetBaseUrl() + "/api/v1/contents/" + c_instanceId + "/namespaces/" + c_namespace + "/names/" +
-              c_productName + "/versYions/" + c_version + "/files?action=GenerateDownloadInfo";
+              c_productName + "/versionYs/" + c_version + "/files?action=GenerateDownloadInfo";
 
         std::string out;
         REQUIRE_THROWS_CODE(connection->Get(url), HttpNotFound);

--- a/client/tests/mock/MockWebServer.cpp
+++ b/client/tests/mock/MockWebServer.cpp
@@ -503,7 +503,7 @@ void MockWebServerImpl::ConfigureGetSpecificVersion()
                 throw StatusCodeException(httplib::StatusCode::InternalServerError_500);
             }
 
-            // TODO: Are apps suppported?
+            // TODO: Are apps supported?
 
             const std::string& version = req.path_params.at("version");
             if (version.empty() || !versions.count(version))

--- a/client/tests/unit/AppContentTests.cpp
+++ b/client/tests/unit/AppContentTests.cpp
@@ -78,13 +78,13 @@ std::unique_ptr<AppContent> GetAppContent(const std::string& contentNameSpace,
                                           const std::vector<AppFile>& files)
 {
     std::unique_ptr<ContentId> contentId = GetContentId(contentNameSpace, contentName, contentVersion);
-    std::vector<AppPrerequisiteContent> clonedPreqs;
+    std::vector<AppPrerequisiteContent> clonedPrereqs;
     for (const auto& prereq : prerequisites)
     {
-        clonedPreqs.push_back(std::move(*GetPrerequisiteContent(prereq.GetContentId().GetNameSpace(),
-                                                                prereq.GetContentId().GetName(),
-                                                                prereq.GetContentId().GetVersion(),
-                                                                prereq.GetFiles())));
+        clonedPrereqs.push_back(std::move(*GetPrerequisiteContent(prereq.GetContentId().GetNameSpace(),
+                                                                  prereq.GetContentId().GetName(),
+                                                                  prereq.GetContentId().GetVersion(),
+                                                                  prereq.GetFiles())));
     }
 
     std::vector<AppFile> clonedFiles;
@@ -100,9 +100,11 @@ std::unique_ptr<AppContent> GetAppContent(const std::string& contentNameSpace,
     }
 
     std::unique_ptr<AppContent> appContent;
-    REQUIRE(
-        AppContent::Make(std::move(contentId), updateId, std::move(clonedPreqs), std::move(clonedFiles), appContent) ==
-        Result::Success);
+    REQUIRE(AppContent::Make(std::move(contentId),
+                             updateId,
+                             std::move(clonedPrereqs),
+                             std::move(clonedFiles),
+                             appContent) == Result::Success);
     REQUIRE(appContent != nullptr);
     return appContent;
 }

--- a/client/tests/unit/details/SFSClientImplTests.cpp
+++ b/client/tests/unit/details/SFSClientImplTests.cpp
@@ -387,7 +387,7 @@ TEST("Testing test override SFS_TEST_OVERRIDE_BASE_URL")
     REQUIRE(sfsClient.MakeUrlBuilder().GetUrl() == "http://customUrl.com/");
 
     {
-        INFO("Can also override a custom base base url with the test key");
+        INFO("Can also override a custom base url with the test key");
         ScopedTestOverride override(TestOverride::BaseUrl, "http://override.com");
         if (AreTestOverridesAllowed())
         {

--- a/samples/README.md
+++ b/samples/README.md
@@ -4,6 +4,6 @@ This folder contains a few samples that show how to use the SFS Client library.
 
 ## integration-do-client
 
-This sample shows how to use the SFSClient to retrieva metadata and URLs from the SFS Service and the [Delivery Optimization SDK](https://github.com/microsoft/do-client) to perform the download of the retrieved URLs.
+This sample shows how to use the SFSClient to retrieve metadata and URLs from the SFS Service and the [Delivery Optimization SDK](https://github.com/microsoft/do-client) to perform the download of the retrieved URLs.
 
 In Windows, the DO SDK uses COM APIs. In Linux, it will require the DO Agent, which is built from the same repository.

--- a/scripts/Setup.ps1
+++ b/scripts/Setup.ps1
@@ -70,7 +70,7 @@ function Install-CMake {
 function Install-CppBuildTools {
     Write-Host -ForegroundColor Cyan "`nInstalling C++ Builds tools if they are not installed"
 
-    # Instaling vswhere, which will be used to query for the required build tools
+    # Installing vswhere, which will be used to query for the required build tools
     try {
         vswhere -? 2>&1 | Out-Null
     }


### PR DESCRIPTION
#### Related Issues

- Closes #224

#### Why is this change being made?

The misspellings have been reported at https://github.com/jsoref/sfs-client/actions/runs/12292227471#summary-34302447496

#### What is being changed?

This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling) (which is an evolution of the script I used ages ago when I first made a PR here...).

#### How was the change tested?

The action reports that the changes in this PR would make it happy: 

https://github.com/jsoref/sfs-client/actions/runs/12292227565#summary-34302447544
<!-- Uncomment the relevant line below -->
<!-- - Current tests test this behavior: <testnames> -->
<!-- - New tests are being added: <testnames> -->
<!-- - Not a functional change. Ex: modifying documentation, auxiliary files, etc -->
