### PR TITLE
Upgrade nlohmann-json to 3.12.0

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "nlohmann-json",
-      "version": "3.11.3"
+      "version": "3.12.0"
     },
     {
       "name": "openssl",


### PR DESCRIPTION
#### Related Issues

For Deliverable 57247654.

Security issues with vulnerable packages from nlohmann-json.

#### Why is this change being made?
Fix the Security issues with vulnerable packages from nlohmann-json.

#### What is being changed?
Upgrade nlohmann-json to 3.12.0

#### How was the change tested?

<!-- Uncomment the relevant line below -->
<!-- - Current tests test this behavior: <testnames> -->
<!-- - New tests are being added: <testnames> -->
<!-- - Not a functional change. Ex: modifying documentation, auxiliary files, etc -->
