### PR TITLE
Update commitHash fro nlohmann-json

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -95,7 +95,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/nlohmann/json",
-          "commitHash": "9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03"
+          "commitHash": "55f93686c01528224f448c19128836e7df245f72"
         }
       },
       "developmentDependency": false


### PR DESCRIPTION
#### Related Issues
For Deliverable 57247654.
Security issues with vulnerable packages from nlohmann-json.

#### Why is this change being made?
cgmanifest.json indicates the dependencies we use for proper automatic scanning of dependencies done in the Azure DevOps backend. It must keep updated to resolve the security on DevOps side.
#### What is being changed?
Update commitHash of nlohmann-json to 55f93686c01528224f448c19128836e7df245f72 which is the commit to release 3.12.0 https://github.com/nlohmann/json/commit/55f93686c01528224f448c19128836e7df245f72.

#### How was the change tested?

<!-- Uncomment the relevant line below -->
<!-- - Current tests test this behavior: <testnames> -->
<!-- - New tests are being added: <testnames> -->
<!-- - Not a functional change. Ex: modifying documentation, auxiliary files, etc -->
