### PR TITLE
Remove brotli

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -101,7 +101,6 @@
       "developmentDependency": false
     },
     {
-      "$comment": "brotli is a transitive dependency of cpp-httplib",
       "component": {
         "type": "git",
         "git": {
@@ -109,7 +108,16 @@
           "commitHash": "028fb5a23661f123017c060daa546b55cf4bde29"
         }
       },
-      "developmentDependency": true
+      "developmentDependency": true,
+      "dependencyRoots": [
+        {
+          "type": "git",
+          "git": {
+            "repositoryUrl": "https://github.com/yhirose/cpp-httplib",
+            "commitHash": "5c00bbf36ba8ff47b4fb97712fc38cb2884e5b98"
+          }
+        }
+      ]
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -99,25 +99,6 @@
         }
       },
       "developmentDependency": false
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "repositoryUrl": "https://github.com/google/brotli",
-          "commitHash": "028fb5a23661f123017c060daa546b55cf4bde29"
-        }
-      },
-      "developmentDependency": true,
-      "dependencyRoots": [
-        {
-          "type": "git",
-          "git": {
-            "repositoryUrl": "https://github.com/yhirose/cpp-httplib",
-            "commitHash": "5c00bbf36ba8ff47b4fb97712fc38cb2884e5b98"
-          }
-        }
-      ]
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -99,6 +99,17 @@
         }
       },
       "developmentDependency": false
+    },
+    {
+      "$comment": "brotli is a transitive dependency of cpp-httplib",
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/google/brotli",
+          "commitHash": "028fb5a23661f123017c060daa546b55cf4bde29"
+        }
+      },
+      "developmentDependency": true
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,10 @@
       "description": "Build tests",
       "dependencies": [
         "catch2",
-        "cpp-httplib"
+        {
+          "name": "cpp-httplib",
+          "default-features": false
+        }
       ]
     }
   },
@@ -53,10 +56,6 @@
     {
       "name": "openssl",
       "version": "3.1.4#1"
-    },
-    {
-      "name": "brotli",
-      "version": "1.2.0"
     }
   ],
   "vcpkg-configuration": {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -53,6 +53,10 @@
     {
       "name": "openssl",
       "version": "3.1.4#1"
+    },
+    {
+      "name": "brotli",
+      "version": "1.2.0"
     }
   ],
   "vcpkg-configuration": {


### PR DESCRIPTION
#### Why is this change being made?
Remove brotli because version < 1.2.0 has a security vulnerability.

(Brotli is a transitive dependency of cpp-httplib, which is used for the mock HTTP server in the functional tests.)

#### What is being changed?

Removed cpp-httplib's usage of brotli, by turning off default-features.

See vcpkg\ports\cpp-httplib\vcpkg.json:
```
  "default-features": [
    "brotli"
  ]
```

#### How was the change tested?

Built clean and passed all tests. Ran Component Governance tool to verify that no issues were found.

<!-- Uncomment the relevant line below -->
<!-- - Current tests test this behavior: <testnames> -->
<!-- - New tests are being added: <testnames> -->
 Not a functional change. Ex: modifying documentation, auxiliary files, etc
