### PR TITLE
Fix Ubuntu Build

### DIFF
--- a/.github/workflows/main-build-ubuntu.yml
+++ b/.github/workflows/main-build-ubuntu.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,7 @@ jobs:
         uses: github/codeql-action/analyze@v3
 
   build-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
#### Why is this change being made?

sfs-client's ubuntu build was failing with "Unsupported Linux distro/version" while building the integration-do-client sample.

The do-client bootstrap script doesn't support Ubuntu 24.04, which is now the default for ubuntu-latest. (See https://github.com/microsoft/do-client/blob/develop/build/scripts/bootstrap.sh#L168). 

#### What is being changed?

 Pinned build workflows to ubuntu-22.04 until do-client adds 24.04 support. 

#### How was the change tested?
Tested that build succeeded in Draft PR.

 Not a functional change. Ex: modifying documentation, auxiliary files, etc
