### PR TITLE
[Draft] Remove workaround that pinned build workflows to ubuntu-22.04

### DIFF
--- a/.github/workflows/main-build-ubuntu.yml
+++ b/.github/workflows/main-build-ubuntu.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-ubuntu:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,7 @@ jobs:
         uses: github/codeql-action/analyze@v3
 
   build-ubuntu:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
{This change is not yet ready because the change in do-client has not merged to main yet}

Reverts microsoft/sfs-client#250

sfs-client's Ubuntu build was failing with "Unsupported Linux distro/version" when building the integration-do-client sample, because the do-client bootstrap script didn't support Ubuntu 24.04, which is now the default for ubuntu-latest. This was fixed with a workaround that pinned build workflows to ubuntu-22.04 until do-client added 24.04 support.

do-client has since been tested on 24.04 and the script has been updated to add 24.04 support (see https://github.com/microsoft/do-client/blob/b80f7024aae05280375109911ec030714403b8b9/build/scripts/bootstrap.sh#L172), so the workaround can be removed.

